### PR TITLE
Created FlybyCamera Class

### DIFF
--- a/Engine/Source/Runtime/Camera.cpp
+++ b/Engine/Source/Runtime/Camera.cpp
@@ -37,37 +37,13 @@ void Camera::SetHomogeneousNdc(bool homogeneousNdc)
 	m_homogeneousNdc = homogeneousNdc;
 }
 
-void Camera::SetEyePosition(bx::Vec3 eye)
-{
-	Dirty();
-	m_eye = std::move(eye);
-}
-
-void Camera::SetLookTargetPosition(bx::Vec3 lookAt)
-{
-	Dirty();
-	m_lookTarget = std::move(lookAt);
-}
-
-void Camera::SetUpDirection(bx::Vec3 up)
-{
-	Dirty();
-	m_up = std::move(up);
-}
-
 void Camera::Update()
 {
 	if (!m_dirty) return;
 
-	m_dirty = false;
-
-	bx::mtxLookAt(m_viewMatrix, m_eye, m_lookTarget, m_up);
 	bx::mtxProj(m_projectionMatrix, m_fov, m_aspect, m_near, m_far, m_homogeneousNdc);
-}
 
-const float* Camera::GetViewMatrix() const
-{
-	return m_viewMatrix;
+	m_dirty = false;
 }
 
 const float* Camera::GetProjectionMatrix() const

--- a/Engine/Source/Runtime/Camera.h
+++ b/Engine/Source/Runtime/Camera.h
@@ -9,7 +9,7 @@ class Camera
 {
 public:
 	Camera() = default;
-	~Camera() = default;
+	virtual ~Camera() = default;
 
 	Camera(const Camera&) = delete;
 	Camera(Camera&&) = delete;
@@ -22,24 +22,16 @@ public:
 	void SetFarPlane(float farPlane);
 	void SetHomogeneousNdc(bool homogeneousNdc);
 
-	void SetEyePosition(bx::Vec3 eye);
-	void SetLookTargetPosition(bx::Vec3 lookAt);
-	void SetUpDirection(bx::Vec3 up);
-
-	const bx::Vec3& GetEyePosition() const { return m_eye; }
-	const bx::Vec3& GetLookTargetPosition() const { return m_lookTarget; }
-	const bx::Vec3& GetUpDirection() const { return m_up; }
-	bx::Vec3& GetEyePositionForWrite() { return m_eye; }
-	bx::Vec3& GetLookTargetPositionForWrite() { return m_lookTarget; }
-	bx::Vec3& GetUpDirectionForWrite() { return m_up; }
-
-	void Update();
-	const float* GetViewMatrix() const;
 	const float* GetProjectionMatrix() const;
 
-	// When camera materix needs to rebuild, we call this status as "dirty".
+	virtual void Update();
+
+	// When camera matrix needs to rebuild, we call this status as "dirty".
 	// Such as the old-fashion algorithm "Dirty Rect".
 	void Dirty() { m_dirty = true; }
+
+protected:
+	bool		m_dirty = true;
 
 private:
 	float		m_aspect;
@@ -48,14 +40,7 @@ private:
 	float		m_far;
 	bool		m_homogeneousNdc;
 
-	bx::Vec3	m_eye					= { 0.0f, 0.0f, 0.0f };
-	bx::Vec3	m_lookTarget			= { 0.0f, 0.0f, 0.0f };
-	bx::Vec3	m_up					= { 0.0f, 0.0f, 0.0f };
-
-	bool		m_dirty					= true;
-
 	// built matrix
-	float		m_viewMatrix[16];
 	float		m_projectionMatrix[16];
 };
 

--- a/Engine/Source/Runtime/FlybyCamera.cpp
+++ b/Engine/Source/Runtime/FlybyCamera.cpp
@@ -1,0 +1,97 @@
+#include "FlybyCamera.h"
+
+#include <memory>
+
+namespace engine
+{
+
+FlybyCamera::FlybyCamera() 
+	: Camera()
+	, m_position(0.0f, 0.0f, 0.0f)
+	, m_orientation(bx::init::Identity)
+{
+	memset(m_viewMatrix, 0, 16 * sizeof(float));
+}
+
+void FlybyCamera::Translate(const bx::Vec3& v)
+{
+	m_position = bx::add(m_position, bx::mul(v, m_orientation));
+	Dirty();
+}
+
+void FlybyCamera::Translate(const float x, const float y, const float z)
+{
+	Translate(bx::Vec3(x, y, z));
+}
+
+void FlybyCamera::Rotate(const bx::Vec3& axis, const float angleDegrees)
+{
+	m_orientation = bx::normalize(bx::fromAxisAngle(axis, angleDegrees));
+	Dirty();
+}
+
+void FlybyCamera::Rotate(const float x, const float y, const float z, const float angleDegrees)
+{
+	Rotate(bx::Vec3(x, y, z), angleDegrees);
+}
+
+void FlybyCamera::Yaw(const float angleDegrees)
+{
+	Rotate(0.0f, 1.0f, 0.0f, angleDegrees);
+}
+
+void FlybyCamera::Pitch(const float angleDegrees)
+{
+	Rotate(1.0f, 0.0f, 0.0f, angleDegrees);
+}
+
+void FlybyCamera::Roll(const float angleDegrees)
+{
+	Rotate(0.0f, 0.0f, 1.0f, angleDegrees);
+}
+
+void FlybyCamera::RotateLocal(const bx::Vec3& axis, const float angleDegrees)
+{
+	const bx::Vec3 rotatedLocalAxis = bx::mul(axis, m_orientation);
+	m_orientation = bx::normalize(bx::fromAxisAngle(rotatedLocalAxis, angleDegrees));
+	Dirty();
+}
+
+void FlybyCamera::RotateLocal(const float x, const float y, const float z, const float angleDegrees)
+{
+	RotateLocal(bx::Vec3(x, y, z), angleDegrees);
+}
+
+void FlybyCamera::YawLocal(const float angleDegrees)
+{
+	RotateLocal(0.0f, 1.0f, 0.0f, angleDegrees);
+}
+
+void FlybyCamera::PitchLocal(const float angleDegrees)
+{
+	RotateLocal(1.0f, 0.0f, 0.0f, angleDegrees);
+}
+
+void FlybyCamera::RollLocal(const float angleDegrees)
+{
+	RotateLocal(0.0f, 0.0f, 1.0f, angleDegrees);
+}
+
+const float* FlybyCamera::GetViewMatrix() const {
+	return m_viewMatrix;
+}
+
+void FlybyCamera::Update()
+{
+	if (!m_dirty) return;
+
+	// Update NDC
+	Camera::Update();
+
+	// Update view matrix
+	bx::mtxFromQuaternion(m_viewMatrix, m_orientation, m_position);
+
+	m_dirty = false;
+}
+
+}	// namespace engine

--- a/Engine/Source/Runtime/FlybyCamera.h
+++ b/Engine/Source/Runtime/FlybyCamera.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "Camera.h"
+
+namespace engine
+{
+
+class FlybyCamera : public Camera
+{
+public:
+	FlybyCamera();
+	~FlybyCamera() = default;
+
+	FlybyCamera(const FlybyCamera&) = delete;
+	FlybyCamera(FlybyCamera&&) = delete;
+	FlybyCamera& operator=(const FlybyCamera&) = delete;
+	FlybyCamera& operator=(FlybyCamera&&) = delete;
+
+	void Translate(const bx::Vec3& v);
+	void Translate(const float x, const float y, const float z);
+	void Rotate(const bx::Vec3& axis, const float angleDegrees);
+	void Rotate(const float x, const float y, const float z, const float angleDegrees);
+	void Yaw(const float angleDegrees);
+	void Pitch(const float angleDegrees);
+	void Roll(const float angleDegrees);
+
+	void RotateLocal(const bx::Vec3& axis, const float angleDegrees);
+	void RotateLocal(const float x, const float y, const float z, const float angleDegrees);
+	void YawLocal(const float angleDegrees);
+	void PitchLocal(const float angleDegrees);
+	void RollLocal(const float angleDegrees);
+
+	const bx::Vec3& GetPosition() const { return m_position; }
+	const bx::Quaternion& GetOrientation() const { return m_orientation; }
+	const float* GetViewMatrix() const;
+
+	void Update() override;
+
+private:
+	bx::Vec3		m_position;
+	bx::Quaternion	m_orientation;
+	float			m_viewMatrix[16];
+};
+
+}	// namespace engine


### PR DESCRIPTION
This deals with view matrix calculation at the same time allowing users to translate and rotate the camera. Camera class will remain the owner for projection matrix calculation. More changes will come to make use of this.