### PR TITLE
Fix mouse double click

### DIFF
--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -198,7 +198,7 @@ bool EditorApp::Update(float deltaTime)
 {
 	GetMainWindow()->Update();
 
-	m_pEditorImGuiContext->Update();
+	m_pEditorImGuiContext->Update(deltaTime);
 	m_pRenderContext->BeginFrame();
 	for (std::unique_ptr<engine::Renderer>& pRenderer : m_pEditorRenderers)
 	{
@@ -216,7 +216,7 @@ bool EditorApp::Update(float deltaTime)
 	}
 
 	m_pEngineImGuiContext->SetWindowPosOffset(m_pSceneView->GetWindowPosX(), m_pSceneView->GetWindowPosY());
-	m_pEngineImGuiContext->Update();
+	m_pEngineImGuiContext->Update(deltaTime);
 	for (std::unique_ptr<engine::Renderer>& pRenderer : m_pEngineRenderers)
 	{
 		const float* pViewMatrix = nullptr;

--- a/Engine/Source/Runtime/ImGui/ImGuiContextInstance.cpp
+++ b/Engine/Source/Runtime/ImGui/ImGuiContextInstance.cpp
@@ -89,7 +89,6 @@ ImGuiContextInstance::ImGuiContextInstance(uint16_t width, uint16_t height, bool
 	io.LogFilename = nullptr;
 
 	io.DisplaySize = ImVec2(static_cast<float>(width), static_cast<float>(height));
-	io.DeltaTime = 1.0f / 60;
 
 	SetImGuiStyles();
 }
@@ -200,9 +199,13 @@ void ImGuiContextInstance::EndDockSpace()
 	ImGui::End();
 }
 
-void ImGuiContextInstance::Update()
+void ImGuiContextInstance::Update(float deltaTime)
 {
 	SwitchCurrentContext();
+
+	// It is necessary to pass correct deltaTime to ImGui underlaying framework because it will use the value to check
+	// something such as if mouse button double click happens(Two click event happens in one frame, < deltaTime).
+	ImGui::GetIO().DeltaTime = deltaTime;
 
 	AddInputEvent();
 

--- a/Engine/Source/Runtime/ImGui/ImGuiContextInstance.h
+++ b/Engine/Source/Runtime/ImGui/ImGuiContextInstance.h
@@ -42,7 +42,7 @@ public:
 	std::vector<std::unique_ptr<ImGuiBaseLayer>>& GetDockableLayers() { return m_pImGuiDockableLayers; }
 	void AddDynamicLayer(std::unique_ptr<ImGuiBaseLayer> pLayer);
 	
-	void Update();
+	void Update(float deltaTime);
 
 	void OnResize(uint16_t width, uint16_t height);
 


### PR DESCRIPTION
ImGui.cpp has a delta time check about mouse double click event : `if ((float)(g.Time - io.MouseClickedTime[i]) < io.MouseDoubleClickTime)`. It depends on correct `g.Time` and `g.Time` is assigned by frame time.