### PR TITLE
Refactor vertex layout logic into render context

### DIFF
--- a/Engine/Source/Runtime/Rendering/BgfxConsumer.cpp
+++ b/Engine/Source/Runtime/Rendering/BgfxConsumer.cpp
@@ -1,5 +1,7 @@
 #include "BgfxConsumer.h"
 
+#include "Rendering/Utility/VertexLayoutUtility.h"
+
 namespace
 {
 
@@ -71,108 +73,6 @@ size_t GetSizeFromAttribType(const bgfx::AttribType::Enum attribType)
 		printf("Unknown attribute type!");
 		assert(false);	// Unknown type!
 		return 0;
-	}
-}
-
-void ConvertVertexLayout(const cd::VertexFormat::VertexAttributeLayout& vertexAttributeLayout, bgfx::VertexLayout& outVertexLayout)
-{
-	bgfx::Attrib::Enum vertexAttrib = bgfx::Attrib::Enum::Count;
-	bgfx::AttribType::Enum vertexAttribValue = bgfx::AttribType::Enum::Count;
-	bool normalized = false;
-
-	// Attribute Type
-	switch (vertexAttributeLayout.vertexAttributeType)
-	{
-	case cd::VertexAttributeType::Position :
-		vertexAttrib = bgfx::Attrib::Enum::Position;
-		break;
-	case cd::VertexAttributeType::Normal:
-		vertexAttrib = bgfx::Attrib::Enum::Normal;
-		normalized = true;
-		break;
-	case cd::VertexAttributeType::Tangent:
-		vertexAttrib = bgfx::Attrib::Enum::Tangent;
-		break;
-	case cd::VertexAttributeType::Bitangent:
-		vertexAttrib = bgfx::Attrib::Enum::Bitangent;
-		break;
-	case cd::VertexAttributeType::UV:
-		vertexAttrib = bgfx::Attrib::Enum::Count;
-		for (const bgfx::Attrib::Enum& textCoord : AllAttribUVTypes)
-		{
-			if (!outVertexLayout.has(textCoord))
-			{
-				vertexAttrib = textCoord;
-				break;
-			}
-		}
-		break;
-	case cd::VertexAttributeType::Color:
-		vertexAttrib = bgfx::Attrib::Enum::Count;
-		for (const bgfx::Attrib::Enum& color : AllAttribColorTypes)
-		{
-			if (!outVertexLayout.has(color))
-			{
-				vertexAttrib = color;
-				break;
-			}
-		}
-		break;
-	default:
-		vertexAttrib = bgfx::Attrib::Enum::Count;
-		break;
-	}
-
-	// Attribute Value
-	switch (vertexAttributeLayout.attributeValueType)
-	{
-	case cd::AttributeValueType::Uint8:
-		vertexAttribValue = bgfx::AttribType::Enum::Uint8;
-		break;
-	case cd::AttributeValueType::Float:
-		vertexAttribValue = bgfx::AttribType::Enum::Float;
-		break;
-	default:
-		vertexAttribValue = bgfx::AttribType::Enum::Count;
-		break;
-	}
-
-	assert(vertexAttrib != bgfx::Attrib::Enum::Count);
-	assert(vertexAttribValue != bgfx::AttribType::Enum::Count);
-	outVertexLayout.add(vertexAttrib, vertexAttributeLayout.attributeCount, vertexAttribValue, normalized);
-}
-
-std::string VertexAttributeTypeToString(const cd::VertexAttributeType& attribType)
-{
-	switch (attribType)
-	{
-		case cd::VertexAttributeType::Position:
-			return "Position";
-		case cd::VertexAttributeType::Normal:
-			return "Normal";
-		case cd::VertexAttributeType::Tangent:
-			return "Tangent";
-		case cd::VertexAttributeType::Bitangent:
-			return "Bitangent";
-		case cd::VertexAttributeType::UV:
-			return "UV";
-		case cd::VertexAttributeType::Color:
-			return "Color";
-		default:
-			return "Invalid Attribute Type!";
-	}
-}
-
-std::string AttributeValueTypeToString(const cd::AttributeValueType& attribValueType)
-{
-	switch (attribValueType)
-	{
-		case cd::AttributeValueType::Float:
-			return "Float";
-		case cd::AttributeValueType::Uint8:
-			return "Uint8";
-		default:
-			return "Invalid Attribute Value Type!";
 	}
 }
 
@@ -293,17 +193,8 @@ void BgfxConsumer::ConvertMeshesFromScene(const cd::SceneDatabase& sceneDatabase
 
 		// Convert vertex formats
  		bgfx::VertexLayout& vertexLayout = meshData.GetVertexLayout();
-		vertexLayout.begin();
-		for (const cd::VertexFormat::VertexAttributeLayout& vertexAttributeLayout : mesh.GetVertexFormat().GetVertexLayout())
-		{
-			printf("\t\tVA: (%s, %s, %d)\n",
-				VertexAttributeTypeToString(vertexAttributeLayout.vertexAttributeType).c_str(),
-				AttributeValueTypeToString(vertexAttributeLayout.attributeValueType).c_str(),
-				vertexAttributeLayout.attributeCount);
-			ConvertVertexLayout(vertexAttributeLayout, vertexLayout);
-		}
-		vertexLayout.end();
-
+		VertexLayoutUtility::CreateVertexLayout(vertexLayout, mesh.GetVertexFormat().GetVertexLayout(), true);
+		
 		// Convert vertices
 		std::vector<std::byte>& rawVertices = meshData.GetRawVertices(); 
 		rawVertices.resize(mesh.GetVertexCount() * vertexLayout.getStride());

--- a/Engine/Source/Runtime/Rendering/RenderContext.cpp
+++ b/Engine/Source/Runtime/Rendering/RenderContext.cpp
@@ -2,6 +2,7 @@
 
 #include "Display/Camera.h"
 #include "Renderer.h"
+#include "Rendering/Utility/VertexLayoutUtility.h"
 
 #include <bgfx/bgfx.h>
 #include <bimg/decode.h>
@@ -331,6 +332,34 @@ bgfx::UniformHandle RenderContext::CreateUniform(const char* pName, bgfx::Unifor
 	}
 
 	return uniformHandle;
+}
+
+bgfx::VertexLayout RenderContext::CreateVertexLayout(StringCrc resourceCrc, const std::vector<cd::VertexFormat::VertexAttributeLayout>& vertexAttributes)
+{
+	auto itVertexLayoutCache = m_vertexLayoutCaches.find(resourceCrc.value());
+	if (itVertexLayoutCache != m_vertexLayoutCaches.end())
+	{
+		return itVertexLayoutCache->second;
+	}
+
+	bgfx::VertexLayout newVertexLayout;
+	VertexLayoutUtility::CreateVertexLayout(newVertexLayout, vertexAttributes);
+	m_vertexLayoutCaches[resourceCrc.value()] = newVertexLayout;
+	return newVertexLayout;
+}
+
+bgfx::VertexLayout RenderContext::CreateVertexLayout(StringCrc resourceCrc, const cd::VertexFormat::VertexAttributeLayout& vertexAttribute)
+{
+	auto itVertexLayoutCache = m_vertexLayoutCaches.find(resourceCrc.value());
+	if (itVertexLayoutCache != m_vertexLayoutCaches.end())
+	{
+		return itVertexLayoutCache->second;
+	}
+
+	bgfx::VertexLayout newVertexLayout;
+	VertexLayoutUtility::CreateVertexLayout(newVertexLayout, vertexAttribute);
+	m_vertexLayoutCaches[resourceCrc.value()] = newVertexLayout;
+	return newVertexLayout;
 }
 
 void RenderContext::SetVertexLayout(StringCrc resourceCrc, bgfx::VertexLayout vertexLayoutHandle)

--- a/Engine/Source/Runtime/Rendering/RenderContext.h
+++ b/Engine/Source/Runtime/Rendering/RenderContext.h
@@ -2,6 +2,7 @@
 
 #include "Core/StringCrc.h"
 #include "RenderTarget.h"
+#include "Scene/VertexFormat.h"
 
 #include <bgfx/bgfx.h>
 
@@ -57,6 +58,8 @@ public:
 	bgfx::TextureHandle CreateTexture(const char *pName, const uint16_t _width, const uint16_t _height, const uint16_t _depth, uint64_t flags = 0UL);
 	bgfx::UniformHandle CreateUniform(const char* pName, bgfx::UniformType::Enum uniformType, uint16_t number = 1);
 
+	bgfx::VertexLayout CreateVertexLayout(StringCrc resourceCrc, const std::vector<cd::VertexFormat::VertexAttributeLayout>& vertexAttributes);
+	bgfx::VertexLayout CreateVertexLayout(StringCrc resourceCrc, const cd::VertexFormat::VertexAttributeLayout& vertexAttribute);
 	void SetVertexLayout(StringCrc resourceCrc, bgfx::VertexLayout textureHandle);
 	void SetTexture(StringCrc resourceCrc, bgfx::TextureHandle textureHandle);
 

--- a/Engine/Source/Runtime/Rendering/Utility/VertexLayoutUtility.cpp
+++ b/Engine/Source/Runtime/Rendering/Utility/VertexLayoutUtility.cpp
@@ -1,0 +1,168 @@
+#include "Rendering/Utility/VertexLayoutUtility.h"
+
+#include <assert.h>
+
+namespace
+{
+
+constexpr bgfx::Attrib::Enum AllAttribColorTypes[] = {
+bgfx::Attrib::Enum::Color0,
+bgfx::Attrib::Enum::Color1,
+bgfx::Attrib::Enum::Color2,
+bgfx::Attrib::Enum::Color3
+};
+constexpr uint32_t MAX_COLOR_COUNT = 4;
+
+constexpr bgfx::Attrib::Enum AllAttribUVTypes[] = {
+	bgfx::Attrib::Enum::TexCoord0,
+	bgfx::Attrib::Enum::TexCoord1,
+	bgfx::Attrib::Enum::TexCoord2,
+	bgfx::Attrib::Enum::TexCoord3,
+	bgfx::Attrib::Enum::TexCoord4,
+	bgfx::Attrib::Enum::TexCoord5,
+	bgfx::Attrib::Enum::TexCoord6,
+	bgfx::Attrib::Enum::TexCoord7
+};
+constexpr uint32_t MAX_UV_COUNT = 8;
+
+std::string VertexAttributeTypeToString(const cd::VertexAttributeType& attribType)
+{
+	switch (attribType)
+	{
+	case cd::VertexAttributeType::Position:
+		return "Position";
+	case cd::VertexAttributeType::Normal:
+		return "Normal";
+	case cd::VertexAttributeType::Tangent:
+		return "Tangent";
+	case cd::VertexAttributeType::Bitangent:
+		return "Bitangent";
+	case cd::VertexAttributeType::UV:
+		return "UV";
+	case cd::VertexAttributeType::Color:
+		return "Color";
+	default:
+		return "Invalid Attribute Type!";
+	}
+}
+
+std::string AttributeValueTypeToString(const cd::AttributeValueType& attribValueType)
+{
+	switch (attribValueType)
+	{
+	case cd::AttributeValueType::Float:
+		return "Float";
+	case cd::AttributeValueType::Uint8:
+		return "Uint8";
+	default:
+		return "Invalid Attribute Value Type!";
+	}
+}
+
+void ConvertVertexLayout(const cd::VertexFormat::VertexAttributeLayout& vertexAttributeLayout, bgfx::VertexLayout& outVertexLayout)
+{
+	bgfx::Attrib::Enum vertexAttrib = bgfx::Attrib::Enum::Count;
+	bgfx::AttribType::Enum vertexAttribValue = bgfx::AttribType::Enum::Count;
+	bool normalized = false;
+
+	// Attribute Type
+	switch (vertexAttributeLayout.vertexAttributeType)
+	{
+	case cd::VertexAttributeType::Position:
+		vertexAttrib = bgfx::Attrib::Enum::Position;
+		break;
+	case cd::VertexAttributeType::Normal:
+		vertexAttrib = bgfx::Attrib::Enum::Normal;
+		normalized = true;
+		break;
+	case cd::VertexAttributeType::Tangent:
+		vertexAttrib = bgfx::Attrib::Enum::Tangent;
+		break;
+	case cd::VertexAttributeType::Bitangent:
+		vertexAttrib = bgfx::Attrib::Enum::Bitangent;
+		break;
+	case cd::VertexAttributeType::UV:
+		vertexAttrib = bgfx::Attrib::Enum::Count;
+		for (const bgfx::Attrib::Enum& textCoord : AllAttribUVTypes)
+		{
+			if (!outVertexLayout.has(textCoord))
+			{
+				vertexAttrib = textCoord;
+				break;
+			}
+		}
+		break;
+	case cd::VertexAttributeType::Color:
+		vertexAttrib = bgfx::Attrib::Enum::Count;
+		for (const bgfx::Attrib::Enum& color : AllAttribColorTypes)
+		{
+			if (!outVertexLayout.has(color))
+			{
+				vertexAttrib = color;
+				break;
+			}
+		}
+		break;
+	default:
+		vertexAttrib = bgfx::Attrib::Enum::Count;
+		break;
+	}
+
+	// Attribute Value
+	switch (vertexAttributeLayout.attributeValueType)
+	{
+	case cd::AttributeValueType::Uint8:
+		vertexAttribValue = bgfx::AttribType::Enum::Uint8;
+		break;
+	case cd::AttributeValueType::Float:
+		vertexAttribValue = bgfx::AttribType::Enum::Float;
+		break;
+	default:
+		vertexAttribValue = bgfx::AttribType::Enum::Count;
+		break;
+	}
+
+	assert(vertexAttrib != bgfx::Attrib::Enum::Count);
+	assert(vertexAttribValue != bgfx::AttribType::Enum::Count);
+	outVertexLayout.add(vertexAttrib, vertexAttributeLayout.attributeCount, vertexAttribValue, normalized);
+}
+
+}
+
+namespace engine
+{
+
+// static
+void VertexLayoutUtility::CreateVertexLayout(bgfx::VertexLayout& outVertexLayout, const std::vector<cd::VertexFormat::VertexAttributeLayout>& vertexAttributes, bool debugPrint /* = false */)
+{
+	outVertexLayout.begin();
+	for (const cd::VertexFormat::VertexAttributeLayout& vertexAttributeLayout : vertexAttributes)
+	{
+		if (debugPrint)
+		{
+			printf("\t\tVA: (%s, %s, %d)\n",
+				VertexAttributeTypeToString(vertexAttributeLayout.vertexAttributeType).c_str(),
+				AttributeValueTypeToString(vertexAttributeLayout.attributeValueType).c_str(),
+				vertexAttributeLayout.attributeCount);
+		}
+		ConvertVertexLayout(vertexAttributeLayout, outVertexLayout);
+	}
+	outVertexLayout.end();
+}
+
+// static
+void VertexLayoutUtility::CreateVertexLayout(bgfx::VertexLayout& outVertexLayout, const cd::VertexFormat::VertexAttributeLayout& vertexAttribute, bool debugPrint /* = false */)
+{
+	outVertexLayout.begin();
+	if (debugPrint)
+	{
+		printf("\t\tVA: (%s, %s, %d)\n",
+			VertexAttributeTypeToString(vertexAttribute.vertexAttributeType).c_str(),
+			AttributeValueTypeToString(vertexAttribute.attributeValueType).c_str(), 
+			vertexAttribute.attributeCount);
+	}
+	ConvertVertexLayout(vertexAttribute, outVertexLayout);
+	outVertexLayout.end();
+}
+
+}

--- a/Engine/Source/Runtime/Rendering/Utility/VertexLayoutUtility.h
+++ b/Engine/Source/Runtime/Rendering/Utility/VertexLayoutUtility.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Scene/VertexFormat.h"
+
+#include <bgfx/bgfx.h>
+
+namespace engine
+{
+
+class VertexLayoutUtility
+{
+public:
+	static void CreateVertexLayout(bgfx::VertexLayout& outVertexLayout, const std::vector<cd::VertexFormat::VertexAttributeLayout>& vertexAttributes, bool debugPrint = false);
+	static void CreateVertexLayout(bgfx::VertexLayout& outVertexLayout, const cd::VertexFormat::VertexAttributeLayout& vertexAttribute, bool debugPrint = false);
+};
+
+}


### PR DESCRIPTION
Refactored VertexLayout logic from BgfxConsumer to a utility class such that it can be used by the render context.