### PR TITLE
Write time cache file after builing tasks

### DIFF
--- a/Engine/Source/Editor/Resources/ResourceBuilder.cpp
+++ b/Engine/Source/Editor/Resources/ResourceBuilder.cpp
@@ -57,13 +57,18 @@ void ResourceBuilder::ReadModifyCacheFile()
 
 void ResourceBuilder::WriteModifyCacheFile()
 {
+	if (!HasNewModifyTimeCache())
+	{
+		return;
+	}
+
 	std::string modifyCachePath = GetModifyCacheFilePath();
 
 	if (!std::filesystem::exists(modifyCachePath))
 	{
 		std::filesystem::create_directories(std::filesystem::path(modifyCachePath).parent_path());
 	}
-		
+
 	std::ofstream outFile(modifyCachePath, std::ios::trunc);
 	if (!outFile.is_open())
 	{
@@ -257,6 +262,16 @@ void ResourceBuilder::Update()
 		process.Run();
 		m_buildTasks.pop();
 	}
+
+	if (m_buildTasks.empty())
+	{
+		WriteModifyCacheFile();
+	}
+}
+
+bool ResourceBuilder::HasNewModifyTimeCache() const
+{
+	return !m_newModifyTimeCache.empty();
 }
 
 void ResourceBuilder::UpdateModifyTimeCache()
@@ -265,6 +280,8 @@ void ResourceBuilder::UpdateModifyTimeCache()
 	{
 		m_modifyTimeCache[filePath] = cd::MoveTemp(fileTime);
 	}
+
+	m_newModifyTimeCache.clear();
 }
 
 void ResourceBuilder::ClearModifyTimeCache()

--- a/Engine/Source/Editor/Resources/ResourceBuilder.h
+++ b/Engine/Source/Editor/Resources/ResourceBuilder.h
@@ -62,16 +62,17 @@ public:
 	bool AddTextureBuildTask(cd::MaterialTextureType textureType, const char* pInputFilePath, const char* pOutputFilePath);
 	void Update();
 
-	void UpdateModifyTimeCache();
-	void ClearModifyTimeCache();
-	void DeleteModifyTimeCache();
-
 private:
 	ResourceBuilder();
 	~ResourceBuilder();
 
 	void ReadModifyCacheFile();
 	void WriteModifyCacheFile();
+
+	bool HasNewModifyTimeCache() const;
+	void UpdateModifyTimeCache();
+	void ClearModifyTimeCache();
+	void DeleteModifyTimeCache();
 
 	std::string GetModifyCacheFilePath();
 


### PR DESCRIPTION
Quit editor by closing console window or other ways will not write file time cache. We write cache file everytime `ResourceBuilder::Update` finishs building all tasks(or no build task) and newTimeCahce hash map already modified(Clear it after `ResourceBuilder::UpdateModifiedTimeCache`).