### PR TITLE
Fix crash when editor launches at the first time

### DIFF
--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -68,6 +68,11 @@ void EditorApp::Init(engine::EngineInitArgs initArgs)
 
 	InitRenderContext(initArgs.backend);
 
+	// Builtin shaders will be compiled automatically when initialization or detect changes.
+	InitShaderPrograms();
+
+	InitRenderGraph();
+
 	// Init ImGuiContext in the editor side which used to draw editor ui.
 	InitEditorImGuiContext(initArgs.language);
 
@@ -78,9 +83,6 @@ void EditorApp::Init(engine::EngineInitArgs initArgs)
 	// Then the imgui window will become a new standalone window. Drop back to convert it back.
 	// TODO : should be only used in the editor ImGuiContext.
 	// InitImGuiViewports(m_pRenderContext);
-
-	// Builtin shaders will be compiled automatically when initialization or detect changes.
-	InitShaderPrograms();
 }
 
 void EditorApp::Shutdown()
@@ -244,21 +246,24 @@ void EditorApp::InitRenderContext(engine::GraphicsBackend backend)
 	m_pRenderContext->Init(backend);
 
 	GetMainWindow()->OnResize.Bind<engine::RenderContext, &engine::RenderContext::OnResize>(m_pRenderContext.get());
+}
 
+void EditorApp::InitRenderGraph()
+{
 	constexpr engine::StringCrc editorSwapChainName("EditorUISwapChain");
 	engine::RenderTarget* pRenderTarget = m_pRenderContext->CreateRenderTarget(editorSwapChainName, GetMainWindow()->GetWidth(), GetMainWindow()->GetHeight(), GetMainWindow()->GetNativeHandle());
 	AddEditorRenderer(std::make_unique<engine::ImGuiRenderer>(m_pRenderContext.get(), m_pRenderContext->CreateView(), pRenderTarget));
 
 	constexpr engine::StringCrc sceneViewRenderTargetName("SceneRenderTarget");
 	std::vector<engine::AttachmentDescriptor> attachmentDesc = {
-		{ .textureFormat = engine::TextureFormat::RGBA32F },
-		{ .textureFormat = engine::TextureFormat::RGBA32F },
-		{ .textureFormat = engine::TextureFormat::D32F },
+		{.textureFormat = engine::TextureFormat::RGBA32F },
+		{.textureFormat = engine::TextureFormat::RGBA32F },
+		{.textureFormat = engine::TextureFormat::D32F },
 	};
 
 	// The init size doesn't make sense. It will resize by SceneView.
 	engine::RenderTarget* pSceneRenderTarget = m_pRenderContext->CreateRenderTarget(sceneViewRenderTargetName, 1, 1, std::move(attachmentDesc));
-	
+
 	auto pPBRSkyRenderer = std::make_unique<engine::PBRSkyRenderer>(m_pRenderContext.get(), m_pRenderContext->CreateView(), pSceneRenderTarget);
 	m_pPBRSkyRenderer = pPBRSkyRenderer.get();
 	AddEngineRenderer(cd::MoveTemp(pPBRSkyRenderer));

--- a/Engine/Source/Editor/EditorApp.h
+++ b/Engine/Source/Editor/EditorApp.h
@@ -46,6 +46,7 @@ public:
 	size_t AddWindow(std::unique_ptr<engine::Window> pWindow);
 
 	void InitRenderContext(engine::GraphicsBackend backend);
+	void InitRenderGraph();
 	void InitShaderPrograms() const;
 	void AddEditorRenderer(std::unique_ptr<engine::Renderer> pRenderer);
 	void AddEngineRenderer(std::unique_ptr<engine::Renderer> pRenderer);


### PR DESCRIPTION
In current init logic:
1. Init EC World
2. Init Bgfx and create GPU resources and renderers
3. Build shaders

After building all shaders, the main thread continues to update. It is OK in the single thread case.
But bgfx will create another render thread to call bgfx::renderframe to flush commands.

We need to split step 2:
1. Init EC World
2. Init Bgfx
3. Build shaders
4. Create GPU resources and renderers

So we will create resources and renderers in the same frame with update logic which can keep safe for recording graphics API commands.

I named step 4 as CreateRenderGraph as we will implement RDG to replace mannual written rendering orders and dependencies.
