### PR TITLE
add emissive for pbr shader

### DIFF
--- a/Engine/Auto/Scripts/editor.lua
+++ b/Engine/Auto/Scripts/editor.lua
@@ -42,6 +42,7 @@ project("Editor")
 		path.join(EngineSourcePath, "Editor/"),
 		path.join(EngineSourcePath, "Runtime/"),
 		path.join(ThirdPartySourcePath, "AssetPipeline/public"),
+		path.join(EnginePath, "BuiltInShaders/shaders"),
 		path.join(EnginePath, "BuiltInShaders/UniformDefines"),
 		-- TODO : Editor should not include bgfx files.
 		path.join(ThirdPartySourcePath, "bgfx/include"),

--- a/Engine/Auto/Scripts/engine.lua
+++ b/Engine/Auto/Scripts/engine.lua
@@ -55,6 +55,7 @@ project("Engine")
 		path.join(ThirdPartySourcePath, "imgui"),
 		path.join(ThirdPartySourcePath, "freetype/include"),
 		table.unpack(platformIncludeDirs),
+		path.join(EnginePath, "BuiltInShaders/shaders"),
 		path.join(EnginePath, "BuiltInShaders/UniformDefines"),
 		path.join(ThirdPartySourcePath, "spdlog/include"),
 	}

--- a/Engine/Auto/Scripts/test.lua
+++ b/Engine/Auto/Scripts/test.lua
@@ -27,8 +27,6 @@ function MakeTest(testName)
 
 		includedirs {
 			path.join(EngineSourcePath, "Runtime/"),
-			path.join(ThirdPartySourcePath, "AssetPipeline/public"),
-			path.join(EnginePath, "BuiltInShaders/UniformDefines"),
 		}
 
 		-- convenient to test multiple threads

--- a/Engine/BuiltInShaders/shaders/fs_PBR_definitions.sh
+++ b/Engine/BuiltInShaders/shaders/fs_PBR_definitions.sh
@@ -1,0 +1,7 @@
+#define ALBEDO_MAP_SLOT 0
+#define NORMAL_MAP_SLOT 1
+#define ORM_MAP_SLOT 2
+#define EMISSIVE_MAP_SLOT 3
+#define LUT_SLOT 4
+#define IBL_ALBEDO_SLOT 5
+#define IBL_IRRADIANCE_SLOT 6

--- a/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
+++ b/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
@@ -36,6 +36,7 @@ const std::unordered_map<cd::MaterialTextureType, engine::Uber> materialTextureT
 	{cd::MaterialTextureType::Occlusion, engine::Uber::OCCLUSION},
 	{cd::MaterialTextureType::Roughness, engine::Uber::ROUGHNESS},
 	{cd::MaterialTextureType::Metallic, engine::Uber::METALLIC},
+	{cd::MaterialTextureType::Emissive, engine::Uber::EMISSIVE},
 };
 
 CD_FORCEINLINE bool IsMaterialTextureTypeValid(cd::MaterialTextureType type)

--- a/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
+++ b/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
@@ -1,5 +1,6 @@
 #include "SceneWorld.h"
 
+#include "fs_PBR_definitions.sh"
 #include "Log/Log.h"
 #include "Path/Path.h"
 
@@ -42,6 +43,7 @@ void SceneWorld::CreatePBRMaterialType()
 	shaderSchema.RegisterUberOption(Uber::OCCLUSION);
 	shaderSchema.RegisterUberOption(Uber::ROUGHNESS);
 	shaderSchema.RegisterUberOption(Uber::METALLIC);
+	shaderSchema.RegisterUberOption(Uber::EMISSIVE);
 	shaderSchema.RegisterUberOption(Uber::IBL);
 	// Technically, option LoadingStatus:: is an actual shader.
 	// We can use AddSingleUberOption to add it to shaderSchema,
@@ -61,12 +63,12 @@ void SceneWorld::CreatePBRMaterialType()
 
 	// Slot index should align to shader codes.
 	// We want basic PBR materials to be flexible.
-	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::BaseColor, 0);
-	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Normal, 1);
-	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Occlusion, 2);
-	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Roughness, 2);
-	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Metallic, 2);
-	//m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Emissive, );
+	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::BaseColor, ALBEDO_MAP_SLOT);
+	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Normal, NORMAL_MAP_SLOT);
+	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Occlusion, ORM_MAP_SLOT);
+	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Roughness, ORM_MAP_SLOT);
+	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Metallic, ORM_MAP_SLOT);
+	m_pPBRMaterialType->AddOptionalTextureType(cd::MaterialTextureType::Emissive, EMISSIVE_MAP_SLOT);
 }
 
 void SceneWorld::CreateAnimationMaterialType()

--- a/Engine/Source/Runtime/Material/ShaderSchema.cpp
+++ b/Engine/Source/Runtime/Material/ShaderSchema.cpp
@@ -21,6 +21,7 @@ constexpr const char* UberNames[] =
 	"OCCLUSION;",
 	"ROUGHNESS;",
 	"METALLIC;",
+	"EMISSIVE;",
 	"IBL;",
 	"AREAL_LIGHT;",
 };

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -20,6 +20,7 @@ enum class Uber : uint32_t
 	OCCLUSION,
 	ROUGHNESS,
 	METALLIC,
+	EMISSIVE,
 
 	// Techniques
 	IBL,

--- a/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
@@ -5,6 +5,7 @@
 #include "ECWorld/SceneWorld.h"
 #include "ECWorld/StaticMeshComponent.h"
 #include "ECWorld/TransformComponent.h"
+#include "fs_PBR_definitions.sh"
 #include "LightUniforms.h"
 #include "Material/ShaderSchema.h"
 #include "RenderContext.h"
@@ -89,18 +90,18 @@ void WorldRenderer::Render(float deltaTime)
 
 		constexpr StringCrc lutSampler("s_texLUT");
 		constexpr StringCrc lutTexture("Textures/lut/ibl_brdf_lut.dds");
-		bgfx::setTexture(3, m_pRenderContext->GetUniform(lutSampler), m_pRenderContext->GetTexture(lutTexture));
+		bgfx::setTexture(LUT_SLOT, m_pRenderContext->GetUniform(lutSampler), m_pRenderContext->GetTexture(lutTexture));
 
 		constexpr StringCrc useIBLCrc("USE_PBR_IBL");
 		if (useIBLCrc == pMaterialComponent->GetUberShaderOption())
 		{
 			constexpr StringCrc cubeSampler("s_texCube");
 			constexpr StringCrc cubeTexture("Textures/skybox/bolonga_lod.dds");
-			bgfx::setTexture(4, m_pRenderContext->GetUniform(cubeSampler), m_pRenderContext->GetTexture(cubeTexture));
+			bgfx::setTexture(IBL_ALBEDO_SLOT, m_pRenderContext->GetUniform(cubeSampler), m_pRenderContext->GetTexture(cubeTexture));
 
 			constexpr StringCrc cubeIrrSampler("s_texCubeIrr");
 			constexpr StringCrc cubeIrrTexture("Textures/skybox/bolonga_irr.dds");
-			bgfx::setTexture(5, m_pRenderContext->GetUniform(cubeIrrSampler), m_pRenderContext->GetTexture(cubeIrrTexture));
+			bgfx::setTexture(IBL_IRRADIANCE_SLOT, m_pRenderContext->GetUniform(cubeIrrSampler), m_pRenderContext->GetTexture(cubeIrrTexture));
 		}
 
 		auto lightEntities = m_pCurrentSceneWorld->GetLightEntities();


### PR DESCRIPTION
TODO : Texture Sampler settings from AssetPipeline.
We should parse some textures as WRAP but CLAMP now so caused some wrong visual results. And tiling properties should also be supported.

![image](https://github.com/CatDogEngine/CatDogEngine/assets/75730859/322caac0-f707-40f6-81cb-ebd4f6ed4bf9)
![image](https://github.com/CatDogEngine/CatDogEngine/assets/75730859/2ca284e3-f3f8-4470-85e6-ee26a4255a81)
