### PR TITLE
fix material texture map mode

### DIFF
--- a/Engine/Source/Editor/ECWorld/ECTerrainConsumer.cpp
+++ b/Engine/Source/Editor/ECWorld/ECTerrainConsumer.cpp
@@ -109,13 +109,15 @@ void ECTerrainConsumer::AddMaterial(engine::Entity entity, const cd::Material* p
 	assert(optElevationTexture.has_value());
 	// Don't need to load as this is generated
 	const cd::Texture& elevationTexture = pSceneDatabase->GetTexture(optElevationTexture.value().Data());
-	materialComponent.AddTextureBlob(elevationTexture.GetType(), elevationTexture.GetTextureFormat(), engine::MaterialComponent::TextureBlob(elevationTexture.GetRawTexture()), elevationTexture.GetWidth(), elevationTexture.GetHeight());
+	materialComponent.AddTextureBlob(elevationTexture.GetType(), elevationTexture.GetTextureFormat(), cd::TextureMapMode::Clamp, cd::TextureMapMode::Clamp,
+		engine::MaterialComponent::TextureBlob(elevationTexture.GetRawTexture()), elevationTexture.GetWidth(), elevationTexture.GetHeight());
 
 	const std::optional<cd::TextureID> optAlphaMapTexture = pMaterial->GetTextureID(cd::MaterialTextureType::AlphaMap);
 	if (optAlphaMapTexture.has_value())
 	{
 		const cd::Texture& alphaMapTexture = pSceneDatabase->GetTexture(optAlphaMapTexture.value().Data());
-		materialComponent.AddTextureBlob(alphaMapTexture.GetType(), alphaMapTexture.GetTextureFormat(), engine::MaterialComponent::TextureBlob(alphaMapTexture.GetRawTexture()), alphaMapTexture.GetWidth(), alphaMapTexture.GetHeight());
+		materialComponent.AddTextureBlob(alphaMapTexture.GetType(), alphaMapTexture.GetTextureFormat(), cd::TextureMapMode::Clamp, cd::TextureMapMode::Clamp,
+			engine::MaterialComponent::TextureBlob(alphaMapTexture.GetRawTexture()), alphaMapTexture.GetWidth(), alphaMapTexture.GetHeight());
 	}
 
 	// Shaders

--- a/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
+++ b/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
@@ -345,7 +345,7 @@ void ECWorldConsumer::AddMaterial(engine::Entity entity, const cd::Material* pMa
 		auto textureFileBlob = ResourceLoader::LoadTextureFile(outputTextureFilePath.c_str());
 		if(!textureFileBlob.empty())
 		{
-			materialComponent.AddTextureFileBlob(pTextureData->GetType(), cd::MoveTemp(textureFileBlob));
+			materialComponent.AddTextureFileBlob(pTextureData->GetType(), pTextureData->GetUMapMode(), pTextureData->GetVMapMode(), cd::MoveTemp(textureFileBlob));
 		}
 	}
 

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
@@ -49,6 +49,50 @@ bgfx::TextureHandle BGFXCreateTexture(
 	return textureHandle;
 }
 
+uint64_t GetBGFXTextureFlag(cd::MaterialTextureType textureType, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode)
+{
+	uint64_t textureFlag = 0;
+	if (cd::MaterialTextureType::BaseColor == textureType ||
+		cd::MaterialTextureType::Emissive == textureType)
+	{
+		textureFlag |= BGFX_TEXTURE_SRGB;
+	}
+
+	switch (uMapMode)
+	{
+	case cd::TextureMapMode::Clamp:
+		textureFlag |= BGFX_SAMPLER_U_CLAMP;
+		break;
+	case cd::TextureMapMode::Mirror:
+		textureFlag |= BGFX_SAMPLER_U_MIRROR;
+		break;
+	case cd::TextureMapMode::Border:
+		textureFlag |= BGFX_SAMPLER_U_BORDER;
+		break;
+	case cd::TextureMapMode::Wrap:
+	default:
+		break;
+	}
+
+	switch (vMapMode)
+	{
+	case cd::TextureMapMode::Clamp:
+		textureFlag |= BGFX_SAMPLER_V_CLAMP;
+		break;
+	case cd::TextureMapMode::Mirror:
+		textureFlag |= BGFX_SAMPLER_V_MIRROR;
+		break;
+	case cd::TextureMapMode::Border:
+		textureFlag |= BGFX_SAMPLER_V_BORDER;
+		break;
+	case cd::TextureMapMode::Wrap:
+	default:
+		break;
+	}
+
+	return textureFlag;
+}
+
 }
 
 namespace engine
@@ -84,12 +128,12 @@ void MaterialComponent::Reset()
 {
 	m_pMaterialData = nullptr;
 	m_pMaterialType = nullptr;
-	m_textureTypeToFileBlob.clear();
 	m_uberShaderOption = ShaderSchema::DefaultUberOption;
 	m_textureResources.clear();
 }
 
-void MaterialComponent::AddTextureBlob(cd::MaterialTextureType textureType, cd::TextureFormat textureFormat, TextureBlob textureBlob, uint32_t width, uint32_t height, uint32_t depth /* = 1 */)
+void MaterialComponent::AddTextureBlob(cd::MaterialTextureType textureType, cd::TextureFormat textureFormat, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode,
+	TextureBlob textureBlob, uint32_t width, uint32_t height, uint32_t depth /* = 1 */)
 {
 	std::optional<uint8_t> optTextureSlot = m_pMaterialType->GetTextureSlot(textureType);
 	if (!optTextureSlot.has_value())
@@ -97,87 +141,50 @@ void MaterialComponent::AddTextureBlob(cd::MaterialTextureType textureType, cd::
 		return;
 	}
 
-	uint64_t textureFlag = BGFX_SAMPLER_U_CLAMP | BGFX_SAMPLER_V_CLAMP;
-	if (cd::MaterialTextureType::BaseColor == textureType)
-	{
-		textureFlag |= BGFX_TEXTURE_SRGB;
-	}
-
-	const bgfx::Memory* pMemory = bgfx::copy(textureBlob.data(), static_cast<uint32_t>(textureBlob.size()));
-
-	m_textureResources[textureType] = TextureInfo();
-	TextureInfo& textureInfo = m_textureResources[textureType];
+	TextureInfo textureInfo = m_textureResources[textureType];
 	textureInfo.slot = optTextureSlot.value();
 	textureInfo.width = width;
 	textureInfo.height = height;
 	textureInfo.depth = depth;
+	textureInfo.mipCount = 0;
 	textureInfo.format = textureFormat;
-	textureInfo.textureHandle =
-		BGFXCreateTexture(
-			textureInfo.width,
-			textureInfo.height,
-			textureInfo.depth,
-			false,
-			textureInfo.mipCount > 1,
-			1,
-			static_cast<bgfx::TextureFormat::Enum>(textureInfo.format),
-			textureFlag,
-			pMemory
-		).idx;
+	textureInfo.data = bgfx::makeRef(textureBlob.data(), static_cast<uint32_t>(textureBlob.size()));
+	textureInfo.flag = GetBGFXTextureFlag(textureType, uMapMode, vMapMode);
+	m_textureResources[textureType] = cd::MoveTemp(textureInfo);
+}
 
-	std::string samplerUniformName = "s_textureSampler";
-	samplerUniformName += std::to_string(textureIndex++);
-	textureInfo.samplerHandle = bgfx::createUniform(samplerUniformName.c_str(), bgfx::UniformType::Sampler).idx;
+void MaterialComponent::AddTextureFileBlob(cd::MaterialTextureType textureType, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode, TextureBlob textureBlob)
+{
+	std::optional<uint8_t> optTextureSlot = m_pMaterialType->GetTextureSlot(textureType);
+	if (!optTextureSlot.has_value())
+	{
+		return;
+	}
+
+	bimg::ImageContainer* pImageContainer = bimg::imageParse(GetResourceAllocator(), textureBlob.data(), static_cast<uint32_t>(textureBlob.size()));
+	TextureInfo textureInfo = m_textureResources[textureType];
+	textureInfo.slot = optTextureSlot.value();
+	textureInfo.width = pImageContainer->m_width;
+	textureInfo.height = pImageContainer->m_height;
+	textureInfo.depth = pImageContainer->m_depth;
+	textureInfo.mipCount = pImageContainer->m_numMips;
+	textureInfo.format = static_cast<cd::TextureFormat>(pImageContainer->m_format);
+	textureInfo.data = bgfx::makeRef(pImageContainer->m_data, pImageContainer->m_size);
+	textureInfo.flag = GetBGFXTextureFlag(textureType, uMapMode, vMapMode);
+	m_textureResources[textureType] = cd::MoveTemp(textureInfo);
 }
 
 void MaterialComponent::Build()
 {
-	// Load texture files
-	for (const auto& [textureType, textureFileBlob] : m_textureTypeToFileBlob)
+	for (auto& [textureType, textureInfo] : m_textureResources)
 	{
-		std::optional<uint8_t> optTextureSlot = m_pMaterialType->GetTextureSlot(textureType);
-		if (!optTextureSlot.has_value())
-		{
-			continue;
-		}
-
-		uint64_t textureFlag = BGFX_SAMPLER_U_CLAMP | BGFX_SAMPLER_V_CLAMP;
-		if (cd::MaterialTextureType::BaseColor == textureType)
-		{
-			textureFlag |= BGFX_TEXTURE_SRGB;
-		}
-
-		// TODO : Customized allocator and free logic.
-		// It may depend on writing our own texture compile tool.
-		bimg::ImageContainer* pImageContainer = bimg::imageParse(GetResourceAllocator(), textureFileBlob.data(), static_cast<uint32_t>(textureFileBlob.size()));
-		const bgfx::Memory* pMemory = bgfx::makeRef(pImageContainer->m_data, pImageContainer->m_size);
-
-		m_textureResources[textureType] = TextureInfo();
-		TextureInfo& textureInfo = m_textureResources[textureType];
-		textureInfo.slot = optTextureSlot.value();
-		textureInfo.samplerHandle = bgfx::kInvalidHandle;
-		textureInfo.textureHandle = bgfx::kInvalidHandle;
-		textureInfo.width = pImageContainer->m_width;
-		textureInfo.height = pImageContainer->m_height;
-		textureInfo.depth = pImageContainer->m_depth;
-		textureInfo.mipCount = pImageContainer->m_numMips;
-		textureInfo.format = static_cast<cd::TextureFormat>(pImageContainer->m_format);
-		textureInfo.textureHandle =
-			BGFXCreateTexture(
-				textureInfo.width,
-				textureInfo.height,
-				textureInfo.depth,
-				pImageContainer->m_cubeMap, 
-				textureInfo.mipCount > 1,
-				pImageContainer->m_numLayers,
-				static_cast<bgfx::TextureFormat::Enum>(textureInfo.format),
-				textureFlag, 
-				pMemory
-			).idx;
+		textureInfo.textureHandle = BGFXCreateTexture(textureInfo.width, textureInfo.height, textureInfo.depth, false, textureInfo.mipCount > 1,
+			1, static_cast<bgfx::TextureFormat::Enum>(textureInfo.format), textureInfo.flag, textureInfo.data).idx;
 
 		std::string samplerUniformName = "s_textureSampler";
 		samplerUniformName += std::to_string(textureIndex++);
 		textureInfo.samplerHandle = bgfx::createUniform(samplerUniformName.c_str(), bgfx::UniformType::Sampler).idx;
+
 		assert(textureInfo.textureHandle != bgfx::kInvalidHandle);
 		assert(textureInfo.samplerHandle != bgfx::kInvalidHandle);
 	}

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.h
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.h
@@ -10,6 +10,13 @@
 #include <optional>
 #include <vector>
 
+namespace bgfx
+{
+
+struct Memory;
+
+}
+
 namespace cd
 {
 
@@ -31,20 +38,19 @@ public:
 		return className;
 	}
 
-	using TextureFileBlob = std::vector<std::byte>;
-
 	using TextureBlob = std::vector<std::byte>;
-
 	struct TextureInfo
 	{
-		uint8_t slot;
-		uint16_t samplerHandle;
-		uint16_t textureHandle;
+		const bgfx::Memory* data;
+		uint64_t flag;
 		uint32_t width;
 		uint32_t height;
 		uint32_t depth;
-		uint8_t mipCount;
 		cd::TextureFormat format;
+		uint16_t samplerHandle;
+		uint16_t textureHandle;
+		uint8_t slot;
+		uint8_t mipCount;
 	};
 
 public:
@@ -59,8 +65,8 @@ public:
 	void SetMaterialType(const engine::MaterialType* pMaterialType) { m_pMaterialType = pMaterialType; }
 	const engine::MaterialType* GetMaterialType() const { return m_pMaterialType; }
 
-	void AddTextureBlob(cd::MaterialTextureType textureType, cd::TextureFormat textureFormat, TextureBlob textureFileBlob, uint32_t width, uint32_t height, uint32_t depth = 1);
-	void AddTextureFileBlob(cd::MaterialTextureType textureType, TextureFileBlob textureFileBlob) { m_textureTypeToFileBlob[textureType] = cd::MoveTemp(textureFileBlob); }
+	void AddTextureBlob(cd::MaterialTextureType textureType, cd::TextureFormat textureFormat, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode, TextureBlob textureBlob, uint32_t width, uint32_t height, uint32_t depth = 1);
+	void AddTextureFileBlob(cd::MaterialTextureType textureType, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode, TextureBlob textureBlob);
 
 	void SetUberShaderOption(StringCrc uberOption);
 	StringCrc GetUberShaderOption() const;
@@ -76,7 +82,6 @@ private:
 	// Input
 	const cd::Material* m_pMaterialData = nullptr;
 	const engine::MaterialType* m_pMaterialType = nullptr;
-	std::map<cd::MaterialTextureType, TextureFileBlob> m_textureTypeToFileBlob;
 	StringCrc m_uberShaderOption;
 
 	// Output

--- a/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
@@ -104,15 +104,15 @@ void WorldRenderer::Render(float deltaTime)
 			bgfx::setTexture(IBL_IRRADIANCE_SLOT, m_pRenderContext->GetUniform(cubeIrrSampler), m_pRenderContext->GetTexture(cubeIrrTexture));
 		}
 
-		auto lightEntities = m_pCurrentSceneWorld->GetLightEntities();
-		size_t lightEntityCount = lightEntities.size();
-		if (lightEntityCount > 0)
-		{
-			// Light component storage has continus memory address and layout.
-			float* pLightDataBegin = reinterpret_cast<float*>(m_pCurrentSceneWorld->GetLightComponent(lightEntities[0]));
-			constexpr engine::StringCrc lightParams("u_lightParams");
-			m_pRenderContext->FillUniform(lightParams, pLightDataBegin, static_cast<uint16_t>(lightEntityCount * LightUniform::LIGHT_STRIDE));
-		}
+		//auto lightEntities = m_pCurrentSceneWorld->GetLightEntities();
+		//size_t lightEntityCount = lightEntities.size();
+		//if (lightEntityCount > 0)
+		//{
+		//	// Light component storage has continus memory address and layout.
+		//	float* pLightDataBegin = reinterpret_cast<float*>(m_pCurrentSceneWorld->GetLightComponent(lightEntities[0]));
+		//	constexpr engine::StringCrc lightParams("u_lightParams");
+		//	m_pRenderContext->FillUniform(lightParams, pLightDataBegin, static_cast<uint16_t>(lightEntityCount * LightUniform::LIGHT_STRIDE));
+		//}
 
 		m_pRenderContext->FillUniform(StringCrc("u_cameraPos"), &pCameraComponent->GetEye().x(), 1);
 


### PR DESCRIPTION
Previously, we are using CLAMP texture sampler mode. But many textures are in wrap mode so that it will cause some sample bugs.