### PR TITLE
use same uv with albedo map to sample normal map

### DIFF
--- a/Engine/BuiltInShaders/shaders/fs_PBR.sc
+++ b/Engine/BuiltInShaders/shaders/fs_PBR.sc
@@ -115,14 +115,16 @@ vec3 CalcuateF0(vec3 albedo, float metallic) {
 Material GetMaterial(vec2 uv, vec3 normal, mat3 TBN) {
 	Material material = CreateMaterial();
 
-#if defined(ALBEDO)
 	vec2 uvOffset = vec2(u_albedoUVOffsetAndScale.x, u_albedoUVOffsetAndScale.y);
 	vec2 uvScale = vec2(u_albedoUVOffsetAndScale.z, u_albedoUVOffsetAndScale.w);
-	material.albedo = SampleAlbedoTexture(uv * uvScale + uvOffset);
+	vec2 albedoUV = uv * uvScale + uvOffset;
+#if defined(ALBEDO)
+	material.albedo = SampleAlbedoTexture(albedoUV);
 #endif
 
 #if defined(NORMAL_MAP)
-	material.normal = SampleNormalTexture(uv, TBN);
+	// Same to unity standard PBR, let normal uv same with albedo uv.
+	material.normal = SampleNormalTexture(albedoUV, TBN);
 #else
 	material.normal = normalize(normal);
 #endif

--- a/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
+++ b/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
@@ -31,12 +31,12 @@ namespace Detail
 const std::unordered_map<cd::MaterialTextureType, engine::Uber> materialTextureType2Uber
 {
 	// TODO : IBL
-	{cd::MaterialTextureType::BaseColor, engine::Uber::ALBEDO},
-	{cd::MaterialTextureType::Normal, engine::Uber::NORMAL_MAP},
-	{cd::MaterialTextureType::Occlusion, engine::Uber::ORM},
-	{cd::MaterialTextureType::Roughness, engine::Uber::ORM},
-	{cd::MaterialTextureType::Metallic, engine::Uber::ORM},
-	{cd::MaterialTextureType::Emissive, engine::Uber::EMISSIVE},
+	{ cd::MaterialTextureType::BaseColor, engine::Uber::ALBEDO_MAP },
+	{ cd::MaterialTextureType::Normal, engine::Uber::NORMAL_MAP },
+	{ cd::MaterialTextureType::Occlusion, engine::Uber::ORM_MAP },
+	{ cd::MaterialTextureType::Roughness, engine::Uber::ORM_MAP },
+	{ cd::MaterialTextureType::Metallic, engine::Uber::ORM_MAP },
+	{ cd::MaterialTextureType::Emissive, engine::Uber::EMISSIVE_MAP },
 };
 
 CD_FORCEINLINE bool IsMaterialTextureTypeValid(cd::MaterialTextureType type)
@@ -356,7 +356,7 @@ void ECWorldConsumer::ActivateUberOption(cd::MaterialTextureType textureType)
 {
 	if (Detail::IsMaterialTextureTypeValid(textureType))
 	{
-		m_activeUberOptions.push_back(Detail::materialTextureType2Uber.at(textureType));
+		m_activeUberOptions.insert(Detail::materialTextureType2Uber.at(textureType));
 	}
 	else
 	{

--- a/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
+++ b/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
@@ -33,9 +33,9 @@ const std::unordered_map<cd::MaterialTextureType, engine::Uber> materialTextureT
 	// TODO : IBL
 	{cd::MaterialTextureType::BaseColor, engine::Uber::ALBEDO},
 	{cd::MaterialTextureType::Normal, engine::Uber::NORMAL_MAP},
-	{cd::MaterialTextureType::Occlusion, engine::Uber::OCCLUSION},
-	{cd::MaterialTextureType::Roughness, engine::Uber::ROUGHNESS},
-	{cd::MaterialTextureType::Metallic, engine::Uber::METALLIC},
+	{cd::MaterialTextureType::Occlusion, engine::Uber::ORM},
+	{cd::MaterialTextureType::Roughness, engine::Uber::ORM},
+	{cd::MaterialTextureType::Metallic, engine::Uber::ORM},
 	{cd::MaterialTextureType::Emissive, engine::Uber::EMISSIVE},
 };
 

--- a/Engine/Source/Editor/ECWorld/ECWorldConsumer.h
+++ b/Engine/Source/Editor/ECWorld/ECWorldConsumer.h
@@ -10,6 +10,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -65,8 +66,8 @@ public:
 	void DeactivateUberOption(cd::MaterialTextureType textureType);
 	void ClearActiveUberOption();
 
-	std::vector<engine::Uber>& GetActiveUberOptions() { return m_activeUberOptions; }
-	const std::vector<engine::Uber>& GetActiveUberOptions() const { return m_activeUberOptions; }
+	std::set<engine::Uber>& GetActiveUberOptions() { return m_activeUberOptions; }
+	const std::set<engine::Uber>& GetActiveUberOptions() const { return m_activeUberOptions; }
 
 	void ActivateDDGIService() { m_meshAssetType = MeshAssetType::DDGI; }
 
@@ -85,7 +86,7 @@ private:
 
 	uint32_t m_nodeMinID;
 	uint32_t m_meshMinID;
-	std::vector<engine::Uber> m_activeUberOptions;
+	std::set<engine::Uber> m_activeUberOptions;
 
 	MeshAssetType m_meshAssetType = MeshAssetType::Standard;
 };

--- a/Engine/Source/Editor/UILayers/Inspector.cpp
+++ b/Engine/Source/Editor/UILayers/Inspector.cpp
@@ -227,6 +227,47 @@ void UpdateComponentWidget<engine::StaticMeshComponent>(engine::SceneWorld* pSce
 }
 
 template<>
+void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pSceneWorld, engine::Entity entity)
+{
+	auto* pMaterialComponent = pSceneWorld->GetMaterialComponent(entity);
+	if (!pMaterialComponent)
+	{
+		return;
+	}
+
+	bool isOpen = ImGui::CollapsingHeader("MaterialComponent", ImGuiTreeNodeFlags_AllowItemOverlap | ImGuiTreeNodeFlags_DefaultOpen);
+	ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+	ImGui::Columns(1);
+	ImGui::Separator();
+	if (isOpen)
+	{
+		ImGui::Columns(2);
+
+		ImGui::TextUnformatted("AlbedoColor");
+		ImGui::NextColumn();
+		ImGui::PushItemWidth(-1);
+
+		ImGui::DragFloat3("##AlbedoColor", pMaterialComponent->GetAlbedoColor().Begin(), 0.01f, 0.0f, 1.0f);
+
+		ImGui::PopItemWidth();
+		ImGui::NextColumn();
+
+		ImGui::TextUnformatted("EmissiveColor");
+		ImGui::NextColumn();
+		ImGui::PushItemWidth(-1);
+
+		ImGui::DragFloat3("##EmissiveColor", pMaterialComponent->GetEmissiveColor().Begin(), 0.01f, 0.0f, 1.0f);
+
+		ImGui::PopItemWidth();
+		ImGui::NextColumn();
+	}
+
+	ImGui::Columns(1);
+	ImGui::Separator();
+	ImGui::PopStyleVar();
+}
+
+template<>
 void UpdateComponentWidget<engine::CameraComponent>(engine::SceneWorld* pSceneWorld, engine::Entity entity)
 {
 	auto* pCameraComponent = pSceneWorld->GetCameraComponent(entity);
@@ -370,8 +411,6 @@ void UpdateComponentWidget<engine::LightComponent>(engine::SceneWorld* pSceneWor
 	ImGui::Separator();
 	ImGui::PopStyleVar();
 }
-
-
 
 }
 

--- a/Engine/Source/Runtime/Application/Engine.cpp
+++ b/Engine/Source/Runtime/Application/Engine.cpp
@@ -20,6 +20,8 @@ Engine::~Engine()
 void Engine::Init(EngineInitArgs args)
 {
 	CD_ENGINE_INFO("Init engine");
+	Window::Init();
+
 	m_pApplication->Init(args);
 }
 
@@ -41,7 +43,7 @@ void Engine::Run()
 
 void Engine::Shutdown()
 {
-
+	Window::Shutdown();
 }
 
 //

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
@@ -180,6 +180,9 @@ void MaterialComponent::AddTextureFileBlob(cd::MaterialTextureType textureType, 
 
 void MaterialComponent::Build()
 {
+	m_albedoColor = cd::Vec3f(1.0f, 1.0f, 1.0f);
+	m_emissiveColor = cd::Vec3f(1.0f, 1.0f, 1.0f);
+
 	for (auto& [textureType, textureInfo] : m_textureResources)
 	{
 		textureInfo.textureHandle = BGFXCreateTexture(textureInfo.width, textureInfo.height, textureInfo.depth, false, textureInfo.mipCount > 1,

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.h
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.h
@@ -72,6 +72,15 @@ public:
 
 	void SetUberShaderOption(StringCrc uberOption);
 	StringCrc GetUberShaderOption() const;
+
+	void SetAlbedoColor(cd::Vec3f color) { m_albedoColor = cd::MoveTemp(color); }
+	cd::Vec3f& GetAlbedoColor() { return m_albedoColor; }
+	const cd::Vec3f& GetAlbedoColor() const { return m_albedoColor; }
+
+	void SetEmissiveColor(cd::Vec3f color) { m_emissiveColor = cd::MoveTemp(color); }
+	cd::Vec3f& GetEmissiveColor() { return m_emissiveColor; }
+	const cd::Vec3f& GetEmissiveColor() const { return m_emissiveColor; }
+
 	uint16_t GetShadingProgram() const;
 
 	std::optional<const TextureInfo> GetTextureInfo(cd::MaterialTextureType textureType) const;
@@ -85,6 +94,9 @@ private:
 	const cd::Material* m_pMaterialData = nullptr;
 	const engine::MaterialType* m_pMaterialType = nullptr;
 	StringCrc m_uberShaderOption;
+
+	cd::Vec3f m_albedoColor;
+	cd::Vec3f m_emissiveColor;
 
 	// Output
 	std::map<cd::MaterialTextureType, TextureInfo> m_textureResources;

--- a/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
+++ b/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
@@ -38,10 +38,10 @@ void SceneWorld::CreatePBRMaterialType()
 	m_pPBRMaterialType->SetMaterialName("CD_PBR");
 
 	ShaderSchema shaderSchema(Path::GetBuiltinShaderInputPath("vs_PBR"), Path::GetBuiltinShaderInputPath("fs_PBR"));
-	shaderSchema.RegisterUberOption(Uber::ALBEDO);
+	shaderSchema.RegisterUberOption(Uber::ALBEDO_MAP);
 	shaderSchema.RegisterUberOption(Uber::NORMAL_MAP);
-	shaderSchema.RegisterUberOption(Uber::ORM);
-	shaderSchema.RegisterUberOption(Uber::EMISSIVE);
+	shaderSchema.RegisterUberOption(Uber::ORM_MAP);
+	shaderSchema.RegisterUberOption(Uber::EMISSIVE_MAP);
 	// TODO : Revert it back after we can import CubeMap such as CmftStudio.
 	//shaderSchema.RegisterUberOption(Uber::IBL);
 

--- a/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
+++ b/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
@@ -40,11 +40,11 @@ void SceneWorld::CreatePBRMaterialType()
 	ShaderSchema shaderSchema(Path::GetBuiltinShaderInputPath("vs_PBR"), Path::GetBuiltinShaderInputPath("fs_PBR"));
 	shaderSchema.RegisterUberOption(Uber::ALBEDO);
 	shaderSchema.RegisterUberOption(Uber::NORMAL_MAP);
-	shaderSchema.RegisterUberOption(Uber::OCCLUSION);
-	shaderSchema.RegisterUberOption(Uber::ROUGHNESS);
-	shaderSchema.RegisterUberOption(Uber::METALLIC);
+	shaderSchema.RegisterUberOption(Uber::ORM);
 	shaderSchema.RegisterUberOption(Uber::EMISSIVE);
-	shaderSchema.RegisterUberOption(Uber::IBL);
+	// TODO : Revert it back after we can import CubeMap such as CmftStudio.
+	//shaderSchema.RegisterUberOption(Uber::IBL);
+
 	// Technically, option LoadingStatus:: is an actual shader.
 	// We can use AddSingleUberOption to add it to shaderSchema,
 	// whithout combine with any other option.

--- a/Engine/Source/Runtime/Material/ShaderSchema.cpp
+++ b/Engine/Source/Runtime/Material/ShaderSchema.cpp
@@ -18,9 +18,7 @@ constexpr const char* UberNames[] =
 	"", // Use empty string to represent default shader option in the name so we can reuse non-uber built shader.
 	"ALBEDO;",
 	"NORMAL_MAP;",
-	"OCCLUSION;",
-	"ROUGHNESS;",
-	"METALLIC;",
+	"USE_ORM;",
 	"EMISSIVE;",
 	"IBL;",
 	"AREAL_LIGHT;",

--- a/Engine/Source/Runtime/Material/ShaderSchema.cpp
+++ b/Engine/Source/Runtime/Material/ShaderSchema.cpp
@@ -16,10 +16,10 @@ namespace details
 constexpr const char* UberNames[] =
 {
 	"", // Use empty string to represent default shader option in the name so we can reuse non-uber built shader.
-	"ALBEDO;",
+	"ALBEDO_MAP;",
 	"NORMAL_MAP;",
-	"USE_ORM;",
-	"EMISSIVE;",
+	"ORM_MAP;",
+	"EMISSIVE_MAP;",
 	"IBL;",
 	"AREAL_LIGHT;",
 };
@@ -128,7 +128,7 @@ uint16_t ShaderSchema::GetCompiledProgram(StringCrc uberOption) const
 	return programHandle;
 }
 
-StringCrc ShaderSchema::GetProgramCrc(const std::vector<Uber>& options) const
+StringCrc ShaderSchema::GetProgramCrc(const std::set<Uber>& options) const
 {
 	if (options.empty())
 	{

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -15,10 +16,10 @@ enum class Uber : uint32_t
 	DEFAULT = 0,
 
 	// PBR parameters
-	ALBEDO,
+	ALBEDO_MAP,
 	NORMAL_MAP,
-	ORM,
-	EMISSIVE,
+	ORM_MAP,
+	EMISSIVE_MAP,
 
 	// Techniques
 	IBL,
@@ -62,7 +63,7 @@ public:
 	void AddSingleUberOption(LoadingStatus status, std::string path);
 
 	bool IsUberOptionValid(StringCrc uberOption) const;
-	StringCrc GetProgramCrc(const std::vector<Uber>& options) const;
+	StringCrc GetProgramCrc(const std::set<Uber>& options) const;
 	StringCrc GetProgramCrc(const LoadingStatus& status) const;
 
 	void SetCompiledProgram(StringCrc uberOption, uint16_t programHandle);

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -17,9 +17,7 @@ enum class Uber : uint32_t
 	// PBR parameters
 	ALBEDO,
 	NORMAL_MAP,
-	OCCLUSION,
-	ROUGHNESS,
-	METALLIC,
+	ORM,
 	EMISSIVE,
 
 	// Techniques

--- a/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
@@ -29,6 +29,8 @@ void WorldRenderer::Init()
 	m_pRenderContext->CreateTexture("Textures/skybox/bolonga_irr.dds", samplerFlags);
 
 	m_pRenderContext->CreateUniform("u_cameraPos", bgfx::UniformType::Vec4, 1);
+	m_pRenderContext->CreateUniform("u_albedoColor", bgfx::UniformType::Vec4, 1);
+	m_pRenderContext->CreateUniform("u_emissiveColor", bgfx::UniformType::Vec4, 1);
 	m_pRenderContext->CreateUniform("u_albedoUVOffsetAndScale", bgfx::UniformType::Vec4, 1);
 
 	bgfx::setViewName(GetViewID(), "WorldRenderer");
@@ -79,6 +81,7 @@ void WorldRenderer::Render(float deltaTime)
 		bgfx::setVertexBuffer(0, bgfx::VertexBufferHandle(pMeshComponent->GetVertexBuffer()));
 		bgfx::setIndexBuffer(bgfx::IndexBufferHandle(pMeshComponent->GetIndexBuffer()));
 
+		// Material
 		for (const auto& [textureType, textureInfo] : pMaterialComponent->GetTextureResources())
 		{
 			std::optional<MaterialComponent::TextureInfo> optTextureInfo = pMaterialComponent->GetTextureInfo(textureType);
@@ -95,6 +98,12 @@ void WorldRenderer::Render(float deltaTime)
 				bgfx::setTexture(textureInfo.slot, bgfx::UniformHandle(textureInfo.samplerHandle), bgfx::TextureHandle(textureInfo.textureHandle));
 			}
 		}
+
+		constexpr StringCrc albedoColor("u_albedoColor");
+		m_pRenderContext->FillUniform(albedoColor, pMaterialComponent->GetAlbedoColor().Begin(), 1);
+
+		constexpr StringCrc emissiveColor("u_emissiveColor");
+		m_pRenderContext->FillUniform(emissiveColor, pMaterialComponent->GetEmissiveColor().Begin(), 1);
 
 		constexpr StringCrc lutSampler("s_texLUT");
 		constexpr StringCrc lutTexture("Textures/lut/ibl_brdf_lut.dds");

--- a/Engine/Source/Runtime/Window/Window.cpp
+++ b/Engine/Source/Runtime/Window/Window.cpp
@@ -16,15 +16,23 @@
 namespace engine
 {
 
-Window::Window(const char* pTitle, uint16_t width, uint16_t height, bool useFullScreen)
-	: m_width(width)
-	, m_height(height)
+void Window::Init()
 {
 	// JoyStick : SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER
 	SDL_Init(SDL_INIT_EVENTS);
 	SDL_SetHintWithPriority("SDL_BORDERLESS_RESIZABLE_STYLE", "1", SDL_HINT_OVERRIDE);
 	SDL_SetHintWithPriority("SDL_BORDERLESS_WINDOWED_STYLE", "1", SDL_HINT_OVERRIDE);
+}
 
+void Window::Shutdown()
+{
+	SDL_Quit();
+}
+
+Window::Window(const char* pTitle, uint16_t width, uint16_t height, bool useFullScreen)
+	: m_width(width)
+	, m_height(height)
+{
 	// If you want to implement window like Visual Studio without titlebar provided by system OS, open SDL_WINDOW_BORDERLESS.
 	// But the issue is that you can't drag it unless you provide an implementation about hit test.
 	// Then you also need to simulate minimize and maxmize buttons.
@@ -48,7 +56,6 @@ Window::Window(const char* pTitle, uint16_t width, uint16_t height, bool useFull
 
 Window::~Window()
 {
-	SDL_Quit();
 	SDL_DestroyWindow(m_pSDLWindow);
 }
 

--- a/Engine/Source/Runtime/Window/Window.h
+++ b/Engine/Source/Runtime/Window/Window.h
@@ -12,6 +12,10 @@ namespace engine
 class Window
 {
 public:
+    static void Init();
+    static void Shutdown();
+
+public:
     Window() = delete;
     Window(const char* pTitle, uint16_t width, uint16_t height, bool useFullScreen = false);
     Window(const Window&) = delete;


### PR DESCRIPTION
* ORM will be a standard. If assets are not ORM, please use AssetPipeline tool to convert. Already added a orm combine tool.
* NormalMap tiling fix.
* For cases if assets are not PBR(no MR properties...), show albedo directly.
* Add albedo color/emissive color uniform in the editor UI. (TODO : Loading status can reuse this uniform, no need to compile more shaders)