### PR TITLE
add alpha test for basic pbr

### DIFF
--- a/Engine/BuiltInShaders/common/Material.sh
+++ b/Engine/BuiltInShaders/common/Material.sh
@@ -19,13 +19,14 @@ struct Material {
 
 uniform vec4 u_albedoColor;
 uniform vec4 u_albedoUVOffsetAndScale;
+uniform vec4 u_alphaCutOff;
 
 #if defined(ALBEDO_MAP)
 SAMPLER2D(s_texBaseColor, ALBEDO_MAP_SLOT);
 
-vec3 SampleAlbedoTexture(vec2 uv) {
+vec4 SampleAlbedoTexture(vec2 uv) {
 	// We assume that albedo texture is already in linear space.
-	return texture2D(s_texBaseColor, uv).xyz;
+	return texture2D(s_texBaseColor, uv);
 }
 #endif
 
@@ -86,7 +87,9 @@ Material GetMaterial(vec2 uv, vec3 normal, mat3 TBN) {
 	vec2 albedoUV = uv * uvScale + uvOffset;
 	
 #if defined(ALBEDO_MAP)
-	material.albedo = SampleAlbedoTexture(albedoUV);
+	vec4 albedoTexture = SampleAlbedoTexture(albedoUV);
+	material.albedo = albedoTexture.xyz;
+	material.opacity = albedoTexture.w;
 #endif
 	material.albedo *= u_albedoColor.xyz;
 

--- a/Engine/BuiltInShaders/shaders/fs_PBR.sc
+++ b/Engine/BuiltInShaders/shaders/fs_PBR.sc
@@ -68,6 +68,11 @@ vec3 GetEnvironment(Material material, vec3 vertexNormal, vec3 viewDir) {
 void main()
 {
 	Material material = GetMaterial(v_texcoord0, v_normal, v_TBN);
+	if (material.opacity < u_alphaCutOff.x)
+	{
+		discard;
+	}
+	
 	vec3 cameraPos = GetCamera().position.xyz;
 	vec3 viewDir = normalize(cameraPos - v_worldPos);
 	

--- a/Engine/Source/Editor/UILayers/Inspector.cpp
+++ b/Engine/Source/Editor/UILayers/Inspector.cpp
@@ -82,7 +82,10 @@ void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pScene
 		ImGuiUtils::ImGuiVectorProperty("EmissiveColor", pMaterialComponent->GetEmissiveColor(), cd::Unit::None, cd::Vec3f::Zero(), cd::Vec3f::One());
 		ImGuiUtils::ImGuiBoolProperty("TwoSided", pMaterialComponent->GetTwoSided());
 		ImGuiUtils::ImGuiStringProperty("BlendMode", cd::GetBlendModeName(pMaterialComponent->GetBlendMode()));
-		ImGuiUtils::ImGuiFloatProperty("AlphaCutOff", pMaterialComponent->GetAlphaCutOff(), cd::Unit::None, 0.0f, 1.0f);
+		if (cd::BlendMode::Mask == pMaterialComponent->GetBlendMode())
+		{
+			ImGuiUtils::ImGuiFloatProperty("AlphaCutOff", pMaterialComponent->GetAlphaCutOff(), cd::Unit::None, 0.0f, 1.0f);
+		}
 	}
 
 	ImGui::Separator();

--- a/Engine/Source/Editor/UILayers/Inspector.cpp
+++ b/Engine/Source/Editor/UILayers/Inspector.cpp
@@ -81,6 +81,8 @@ void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pScene
 		ImGuiUtils::ImGuiVectorProperty("AlbedoColor", pMaterialComponent->GetAlbedoColor(), cd::Unit::None, cd::Vec3f::Zero(), cd::Vec3f::One());
 		ImGuiUtils::ImGuiVectorProperty("EmissiveColor", pMaterialComponent->GetEmissiveColor(), cd::Unit::None, cd::Vec3f::Zero(), cd::Vec3f::One());
 		ImGuiUtils::ImGuiBoolProperty("TwoSided", pMaterialComponent->GetTwoSided());
+		ImGuiUtils::ImGuiStringProperty("BlendMode", cd::GetBlendModeName(pMaterialComponent->GetBlendMode()));
+		ImGuiUtils::ImGuiFloatProperty("AlphaCutOff", pMaterialComponent->GetAlphaCutOff(), cd::Unit::None, 0.0f, 1.0f);
 	}
 
 	ImGui::Separator();

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
@@ -100,8 +100,6 @@ namespace engine
 
 void MaterialComponent::Init(const engine::MaterialType* pMaterialType, const cd::Material* pMaterialData)
 {
-	Reset();
-
 	m_pMaterialData = pMaterialData;
 	m_pMaterialType = pMaterialType;
 }
@@ -140,6 +138,8 @@ void MaterialComponent::Reset()
 	m_albedoColor = cd::Vec3f::One();
 	m_emissiveColor = cd::Vec3f::One();
 	m_twoSided = false;
+	m_blendMode = cd::BlendMode::Opaque;
+	m_alphaCutOff = 1.0f;
 	m_textureResources.clear();
 }
 

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
@@ -98,6 +98,11 @@ uint64_t GetBGFXTextureFlag(cd::MaterialTextureType textureType, cd::TextureMapM
 namespace engine
 {
 
+MaterialComponent::MaterialComponent()
+{
+	Reset();
+}
+
 void MaterialComponent::Init(const engine::MaterialType* pMaterialType, const cd::Material* pMaterialData)
 {
 	m_pMaterialData = pMaterialData;

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.h
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.h
@@ -56,7 +56,7 @@ public:
 	};
 
 public:
-	MaterialComponent() = default;
+	MaterialComponent() { Reset(); }
 	MaterialComponent(const MaterialComponent&) = default;
 	MaterialComponent& operator=(const MaterialComponent&) = default;
 	MaterialComponent(MaterialComponent&&) = default;
@@ -66,11 +66,20 @@ public:
 	void Init(const engine::MaterialType* pMaterialType, const cd::Material* pMaterialData = nullptr);
 	const engine::MaterialType* GetMaterialType() const { return m_pMaterialType; }
 
+	void Reset();
+	void Build();
+
+	// Shader data.
+	void SetUberShaderOption(StringCrc uberOption);
+	StringCrc GetUberShaderOption() const;
+	uint16_t GetShadingProgram() const;
+
+	// Texture data.
 	void AddTextureBlob(cd::MaterialTextureType textureType, cd::TextureFormat textureFormat, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode, TextureBlob textureBlob, uint32_t width, uint32_t height, uint32_t depth = 1);
 	void AddTextureFileBlob(cd::MaterialTextureType textureType, const cd::Texture& texture, TextureBlob textureBlob);
 
-	void SetUberShaderOption(StringCrc uberOption);
-	StringCrc GetUberShaderOption() const;
+	std::optional<const TextureInfo> GetTextureInfo(cd::MaterialTextureType textureType) const;
+	const std::map<cd::MaterialTextureType, TextureInfo>& GetTextureResources() const { return m_textureResources; }
 
 	void SetAlbedoColor(cd::Vec3f color) { m_albedoColor = cd::MoveTemp(color); }
 	cd::Vec3f& GetAlbedoColor() { return m_albedoColor; }
@@ -80,17 +89,19 @@ public:
 	cd::Vec3f& GetEmissiveColor() { return m_emissiveColor; }
 	const cd::Vec3f& GetEmissiveColor() const { return m_emissiveColor; }
 
+	// Cull parameters. 
 	void SetTwoSided(bool value) { m_twoSided = value; }
 	bool& GetTwoSided() { return m_twoSided; }
 	bool GetTwoSided() const { return m_twoSided; }
 
-	uint16_t GetShadingProgram() const;
+	// Blend parameters.
+	void SetBlendMode(cd::BlendMode blendMode) { m_blendMode = blendMode; }
+	cd::BlendMode& GetBlendMode() { return m_blendMode; }
+	cd::BlendMode GetBlendMode() const { return m_blendMode; }
 
-	std::optional<const TextureInfo> GetTextureInfo(cd::MaterialTextureType textureType) const;
-	const std::map<cd::MaterialTextureType, TextureInfo>& GetTextureResources() const { return m_textureResources; }
-
-	void Reset();
-	void Build();
+	void SetAlphaCutOff(float value) { m_alphaCutOff = value; }
+	float& GetAlphaCutOff() { return m_alphaCutOff; }
+	float GetAlphaCutOff() const { return m_alphaCutOff; }
 
 private:
 	// Input
@@ -101,6 +112,8 @@ private:
 	cd::Vec3f m_albedoColor;
 	cd::Vec3f m_emissiveColor;
 	bool m_twoSided;
+	cd::BlendMode m_blendMode;
+	float m_alphaCutOff;
 
 	// Output
 	std::map<cd::MaterialTextureType, TextureInfo> m_textureResources;

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.h
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.h
@@ -56,7 +56,7 @@ public:
 	};
 
 public:
-	MaterialComponent() { Reset(); }
+	MaterialComponent();
 	MaterialComponent(const MaterialComponent&) = default;
 	MaterialComponent& operator=(const MaterialComponent&) = default;
 	MaterialComponent(MaterialComponent&&) = default;

--- a/Engine/Source/Runtime/ImGui/ImGuiUtils.hpp
+++ b/Engine/Source/Runtime/ImGui/ImGuiUtils.hpp
@@ -16,14 +16,14 @@ static bool ImGuiBoolProperty(const char* pName, bool& value)
 	return ImGui::Checkbox(pName, &value);
 }
 
-static bool ImGuiStringProperty(const char* pName, std::string& value)
+static bool ImGuiStringProperty(const char* pName, const char* pValue)
 {
 	ImGui::Columns(2);
 	ImGui::TextUnformatted(pName);
 	ImGui::NextColumn();
 	ImGui::PushItemWidth(-1);
 
-	ImGui::TextUnformatted(value.c_str());
+	ImGui::TextUnformatted(pValue);
 
 	ImGui::PopItemWidth();
 	ImGui::NextColumn();
@@ -31,6 +31,11 @@ static bool ImGuiStringProperty(const char* pName, std::string& value)
 
 	// TODO : editable
 	return false;
+}
+
+static bool ImGuiStringProperty(const char* pName, const std::string& value)
+{
+	return ImGuiStringProperty(pName, value.c_str());
 }
 
 static bool ImGuiFloatProperty(const char* pName, float& value, cd::Unit unit = cd::Unit::None, float minValue = {}, float maxValue = {}, bool isNormalized = false, float speed = -1.0f)

--- a/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
@@ -34,6 +34,7 @@ void WorldRenderer::Init()
 	m_pRenderContext->CreateUniform("u_albedoColor", bgfx::UniformType::Vec4, 1);
 	m_pRenderContext->CreateUniform("u_emissiveColor", bgfx::UniformType::Vec4, 1);
 	m_pRenderContext->CreateUniform("u_albedoUVOffsetAndScale", bgfx::UniformType::Vec4, 1);
+	m_pRenderContext->CreateUniform("u_alphaCutOff", bgfx::UniformType::Vec4, 1);
 
 	bgfx::setViewName(GetViewID(), "WorldRenderer");
 }
@@ -151,6 +152,13 @@ void WorldRenderer::Render(float deltaTime)
 		{
 			state |= BGFX_STATE_CULL_CCW;
 		}
+
+		if (cd::BlendMode::Mask == pMaterialComponent->GetBlendMode())
+		{
+			constexpr StringCrc uvOffsetAndScale("u_alphaCutOff");
+			m_pRenderContext->FillUniform(uvOffsetAndScale, &pMaterialComponent->GetAlphaCutOff(), 1);
+		}
+
 		bgfx::setState(state);
 
 		bgfx::submit(GetViewID(), bgfx::ProgramHandle(pMaterialComponent->GetShadingProgram()));


### PR DESCRIPTION
![image](https://github.com/CatDogEngine/CatDogEngine/assets/75730859/e0a0b98f-727a-4d36-b973-b7c957af8cbe)

add BlendMode Mask to control alpha cutoff value.

It is better to write a standalone tree material type but OK in simple usage.

Test:
https://github.com/CatDogEngine/TestAssets/blob/main/Tree/oak_trees.zip