### PR TITLE
Add submodule update choice bat.

### DIFF
--- a/UpdateSubmodules.bat
+++ b/UpdateSubmodules.bat
@@ -1,4 +1,4 @@
 git submodule init
-git submodule update --recursive --remote
+git submodule update --recursive
 
 pause

--- a/UpdateSubmodules.bat
+++ b/UpdateSubmodules.bat
@@ -1,3 +1,5 @@
+git pull
+
 git submodule init
 git submodule update --recursive
 

--- a/UpdateSubmodulesRemote.bat
+++ b/UpdateSubmodulesRemote.bat
@@ -1,0 +1,4 @@
+git submodule init
+git submodule update --recursive --remote
+
+pause


### PR DESCRIPTION
Run `UpdateSubmodulesRemote.bat` to update submodules to the latest version of submodules' repo.
If you don't want to update the submodules' commit vertion of CatDogEngine repo, run `UpdateSubmodules.bat`.
Note that `UpdateSubmodules.bat` will run `git pull` before `git submodule update`.

Theres no difference between the previous `UpdateSubmodules.bat` and the current `UpdateSubmodulesRemote.bat`.