### PR TITLE
fix frame all

### DIFF
--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -146,11 +146,15 @@ void EditorApp::InitEditorImGuiContext(engine::Language language)
 
 void EditorApp::InitEditorUILayers()
 {
-	// Add UI layers after finish imgui and rendering contexts' initialization.
-	m_pEditorImGuiContext->AddStaticLayer(std::make_unique<MainMenu>("MainMenu"));
+	InitEditorController();
 
+	// Add UI layers after finish imgui and rendering contexts' initialization.
+	auto pMainMenu = std::make_unique<MainMenu>("MainMenu");
+	pMainMenu->SetCameraController(m_pViewportCameraController.get());
+	m_pEditorImGuiContext->AddStaticLayer(cd::MoveTemp(pMainMenu));
+	
 	auto pEntityList = std::make_unique<EntityList>("EntityList");
-	pEntityList->SetCameraController(m_pCameraController);
+	pEntityList->SetCameraController(m_pViewportCameraController.get());
 	m_pEditorImGuiContext->AddDynamicLayer(cd::MoveTemp(pEntityList));
 
 	//m_pEditorImGuiContext->AddDynamicLayer(std::make_unique<GameView>("GameView"));
@@ -408,15 +412,15 @@ void EditorApp::InitShaderPrograms() const
 	ShaderBuilder::BuildUberShader(m_pSceneWorld->GetDDGIMaterialType());
 }
 
-void EditorApp::InitController()
+void EditorApp::InitEditorController()
 {
 	// Controller for Input events.
-	m_pCameraController = std::make_shared<engine::CameraController>(
+	m_pViewportCameraController = std::make_unique<engine::CameraController>(
 		m_pSceneWorld.get(),
 		12.0f /* horizontal sensitivity */,
 		12.0f /* vertical sensitivity */,
 		30.0f /* Movement Speed*/);
-	m_pCameraController->CameraToController();
+	m_pViewportCameraController->CameraToController();
 }
 
 void EditorApp::AddEditorRenderer(std::unique_ptr<engine::Renderer> pRenderer)
@@ -464,7 +468,6 @@ bool EditorApp::Update(float deltaTime)
 
 			InitEngineRenderers();
 			m_pEditorImGuiContext->ClearUILayers();
-			InitController();
 			InitEditorUILayers();
 
 			InitEngineImGuiContext(m_initArgs.language);
@@ -475,9 +478,9 @@ bool EditorApp::Update(float deltaTime)
 	}
 	else
 	{
-		if (m_pCameraController)
+		if (m_pViewportCameraController)
 		{
-			m_pCameraController->Update(deltaTime);
+			m_pViewportCameraController->Update(deltaTime);
 		}
 	}
 

--- a/Engine/Source/Editor/EditorApp.h
+++ b/Engine/Source/Editor/EditorApp.h
@@ -62,7 +62,7 @@ public:
 	void RegisterImGuiUserData(engine::ImGuiContextInstance* pImGuiContext);
 
 	void InitECWorld();
-	void InitController();
+	void InitEditorController();
 
 	bool IsAtmosphericScatteringEnable() const;
 
@@ -96,7 +96,7 @@ private:
 	std::vector<std::unique_ptr<engine::Renderer>> m_pEngineRenderers;
 
 	// Controllers for processing input events.
-	std::shared_ptr<engine::CameraController> m_pCameraController;
+	std::unique_ptr<engine::CameraController> m_pViewportCameraController;
 };
 
 }

--- a/Engine/Source/Editor/UILayers/EntityList.cpp
+++ b/Engine/Source/Editor/UILayers/EntityList.cpp
@@ -1,5 +1,6 @@
 #include "EntityList.h"
 
+#include "Display/CameraController.h"
 #include "ECWorld/SceneWorld.h"
 #include "ECWorld/World.h"
 #include "ImGui/IconFont/IconsMaterialDesignIcons.h"
@@ -293,8 +294,6 @@ void EntityList::DrawEntity(engine::SceneWorld* pSceneWorld, engine::Entity enti
                         m_pCameraController->CameraFocus(meshAABB);
                     }
                 }
-
-      
             }
         }
     }

--- a/Engine/Source/Editor/UILayers/EntityList.h
+++ b/Engine/Source/Editor/UILayers/EntityList.h
@@ -1,6 +1,5 @@
 #include "ImGui/ImGuiBaseLayer.h"
 
-#include "Display/CameraController.h"
 #include "ECWorld/Entity.h"
 
 #include <imgui/imgui.h>
@@ -29,12 +28,12 @@ public:
 	void AddEntity(engine::SceneWorld* pSceneWorld);
 	void DrawEntity(engine::SceneWorld* pSceneWorld, engine::Entity entity);
 
-	void SetCameraController(std::shared_ptr<engine::CameraController> cameraController) { m_pCameraController = cameraController; }
+	void SetCameraController(engine::CameraController* pCameraController) { m_pCameraController = pCameraController; }
 
 
 private:
 	ImGuiTextFilter m_entityFilter;
-	std::shared_ptr<engine::CameraController> m_pCameraController;
+	engine::CameraController* m_pCameraController = nullptr;
 };
 
 }

--- a/Engine/Source/Editor/UILayers/MainMenu.h
+++ b/Engine/Source/Editor/UILayers/MainMenu.h
@@ -9,6 +9,13 @@ class FileBrowser;
 
 }
 
+namespace engine
+{
+
+class CameraController;
+
+}
+
 namespace editor
 {
 
@@ -27,8 +34,12 @@ public:
 	void WindowMenu();
 	void BuildMenu();
 	void AboutMenu();
+
+	void SetCameraController(engine::CameraController* pCameraController) { m_pCameraController = pCameraController; }
+
 private:
 	std::unique_ptr<ImGui::FileBrowser> m_pCreatProjectDialog;
+	engine::CameraController* m_pCameraController = nullptr;
 };
 
 }

--- a/Engine/Source/Game/GameApp.cpp
+++ b/Engine/Source/Game/GameApp.cpp
@@ -289,7 +289,7 @@ bool GameApp::IsAtmosphericScatteringEnable() const
 void GameApp::InitController()
 {
 	// Controller for Input events.
-	m_pCameraController = std::make_shared<engine::CameraController>(
+	m_pCameraController = std::make_unique<engine::CameraController>(
 		m_pSceneWorld.get(),
 		12.0f /* horizontal sensitivity */,
 		12.0f /* vertical sensitivity */,

--- a/Engine/Source/Game/GameApp.h
+++ b/Engine/Source/Game/GameApp.h
@@ -86,7 +86,7 @@ private:
 	std::vector<std::unique_ptr<engine::Renderer>> m_pEngineRenderers;
 
 	// Controllers for processing input events.
-	std::shared_ptr<engine::CameraController> m_pCameraController;
+	std::unique_ptr<engine::CameraController> m_pCameraController;
 };
 
 }

--- a/Engine/Source/Runtime/ECWorld/CameraComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/CameraComponent.cpp
@@ -22,21 +22,6 @@ void CameraComponent::BuildProjectMatrix()
 	m_projectionMatrix = cd::Matrix4x4::Perspective(m_fov, m_aspect, m_nearPlane, m_farPlane, cd::NDCDepth::MinusOneToOne == m_ndcDepth);
 }
 
-void CameraComponent::FrameAll(const cd::AABB& aabb)
-{
-	if (aabb.IsEmpty())
-	{
-		return;
-	}
-
-	cd::Point lookAt = aabb.Center();
-	cd::Direction lookDirection(0.0f, 0.0f, 1.0f);
-	lookDirection.Normalize();
-
-	cd::Point lookFrom = lookAt - lookDirection * aabb.Size().Length();
-	m_isViewDirty = true;
-}
-
 cd::Ray CameraComponent::EmitRay(float screenX, float screenY, float width, float height) const
 {
 	cd::Matrix4x4 vpInverse = m_projectionMatrix * m_viewMatrix;
@@ -75,6 +60,22 @@ void CameraComponent::SetCross(const cd::Vec3f& cross, cd::Transform& transform)
 	cd::Vec3f rotAxis = GetCross(transform).Cross(cross);
 	float rotAngle = std::acos(GetUp(transform).Dot(cross));
 	transform.SetRotation(transform.GetRotation() * cd::Quaternion::FromAxisAngle(rotAxis, rotAngle));
+}
+
+void CameraComponent::FrameAll(const cd::AABB& aabb, cd::Transform& transform)
+{
+	if (aabb.IsEmpty())
+	{
+		return;
+	}
+
+	cd::Point lookAt = aabb.Center();
+	cd::Direction lookDirection(0.0f, 0.0f, 1.0f);
+	lookDirection.Normalize();
+	SetLookAt(lookDirection, transform);
+
+	cd::Point lookFrom = lookAt - lookDirection * aabb.Size().Length();
+	transform.SetTranslation(cd::MoveTemp(lookFrom));
 }
 
 }

--- a/Engine/Source/Runtime/ECWorld/CameraComponent.h
+++ b/Engine/Source/Runtime/ECWorld/CameraComponent.h
@@ -2,9 +2,8 @@
 
 #include "Core/StringCrc.h"
 #include "Math/Box.hpp"
-#include "Math/Matrix.hpp"
 #include "Math/Ray.hpp"
-#include "TransformComponent.h"
+#include "Math/Transform.hpp"
 
 namespace cd
 {
@@ -33,7 +32,6 @@ public:
 	CameraComponent& operator=(CameraComponent&&) = default;
 	~CameraComponent() = default;
 
-	void FrameAll(const cd::AABB& aabb);
 	cd::Ray EmitRay(float screenX, float screenY, float width, float height) const;
 
 	void SetAspect(float aspect) { m_aspect = aspect; m_isProjectionDirty = true; }
@@ -63,7 +61,7 @@ public:
 	static void SetLookAt(const cd::Vec3f& lookAt, cd::Transform& transform);
 	static void SetUp(const cd::Vec3f& up, cd::Transform& transform);
 	static void SetCross(const cd::Vec3f& cross, cd::Transform& transform);
-
+	static void FrameAll(const cd::AABB& aabb, cd::Transform& transform);
 
 	const cd::Matrix4x4& GetViewMatrix() const { return m_viewMatrix; }
 	void BuildViewMatrix(const cd::Transform& tranform);


### PR DESCRIPTION
Cause:
Skybox mesh involves the AABB calculation and view matrix doesn't update correctly after previous Camera refact.

TODO :
1. CollisionMeshComponent so that FrameAll will use it, not StaticMesh which will involve sky box mesh.
2. Write OnMouseDown/Up callbacks for users to write UI logics more conveniently.