### PR TITLE
Skip the specified uber option combination.

### DIFF
--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -386,7 +386,7 @@ void EditorApp::InitEngineRenderers()
 bool EditorApp::IsAtmosphericScatteringEnable() const
 {
 	engine::GraphicsBackend backend = engine::Path::GetGraphicsBackend();
-	
+
 	return engine::GraphicsBackend::Vulkan != backend
 		&& engine::GraphicsBackend::OpenGL != backend
 		&& engine::GraphicsBackend::OpenGLES != backend;

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -385,8 +385,11 @@ void EditorApp::InitEngineRenderers()
 
 bool EditorApp::IsAtmosphericScatteringEnable() const
 {
-	return engine::GraphicsBackend::OpenGL != engine::Path::GetGraphicsBackend() &&
-		engine::GraphicsBackend::Vulkan != engine::Path::GetGraphicsBackend();
+	engine::GraphicsBackend backend = engine::Path::GetGraphicsBackend();
+	return true
+		&& engine::GraphicsBackend::Vulkan == backend
+		&& engine::GraphicsBackend::OpenGL == backend
+		&& engine::GraphicsBackend::OpenGLES == backend;
 }
 
 void EditorApp::InitShaderPrograms() const

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -386,10 +386,10 @@ void EditorApp::InitEngineRenderers()
 bool EditorApp::IsAtmosphericScatteringEnable() const
 {
 	engine::GraphicsBackend backend = engine::Path::GetGraphicsBackend();
-	return true
-		&& engine::GraphicsBackend::Vulkan == backend
-		&& engine::GraphicsBackend::OpenGL == backend
-		&& engine::GraphicsBackend::OpenGLES == backend;
+	
+	return engine::GraphicsBackend::Vulkan != backend
+		&& engine::GraphicsBackend::OpenGL != backend
+		&& engine::GraphicsBackend::OpenGLES != backend;
 }
 
 void EditorApp::InitShaderPrograms() const

--- a/Engine/Source/Editor/Resources/ShaderBuilder.cpp
+++ b/Engine/Source/Editor/Resources/ShaderBuilder.cpp
@@ -25,7 +25,7 @@ void ShaderBuilder::BuildUberShader(engine::MaterialType* pMaterialType)
 			shaderSchema.GetFragmentShaderPath(), outputFSFilePath.c_str(), combine.c_str());
 	}
 
-	CD_ENGINE_INFO("Material type {0} have shader variant count : {1}.", pMaterialType->GetMaterialName(), shaderSchema.GetUberCombines().size());
+	CD_ENGINE_INFO("Shader variant count of material type {0} : {1}", pMaterialType->GetMaterialName(), shaderSchema.GetUberCombines().size());
 }
 
 void ShaderBuilder::BuildNonUberShader(std::string folderPath)

--- a/Engine/Source/Editor/UILayers/AssetBrowser.cpp
+++ b/Engine/Source/Editor/UILayers/AssetBrowser.cpp
@@ -348,7 +348,7 @@ void AssetBrowser::UpdateAssetFolderTree()
 			//m_pImportFileBrowser->SetTypeFilters({ ".dds", "*.exr", "*.hdr", "*.ktx", ".tga" });
 			m_pImportFileBrowser->Open();
 
-			CD_INFO("Import asset type: {}", GetDDGITextureTypeName(m_importOptions.AssetType));
+			CD_INFO("Import asset type: {}", GetIOAssetTypeName(m_importOptions.AssetType));
 		}
 
 		else if (ImGui::Selectable("Shader"))
@@ -358,7 +358,7 @@ void AssetBrowser::UpdateAssetFolderTree()
 			//m_pImportFileBrowser->SetTypeFilters({ ".sc" }); // ".hlsl"
 			m_pImportFileBrowser->Open();
 
-			CD_INFO("Import asset type: {}", GetDDGITextureTypeName(m_importOptions.AssetType));
+			CD_INFO("Import asset type: {}", GetIOAssetTypeName(m_importOptions.AssetType));
 		}
 		else if (ImGui::Selectable("Model"))
 		{
@@ -367,23 +367,26 @@ void AssetBrowser::UpdateAssetFolderTree()
 			//m_pImportFileBrowser->SetTypeFilters({ ".fbx", ".gltf" }); // ".obj", ".dae", ".ogex"
 			m_pImportFileBrowser->Open();
 
-			CD_INFO("Import asset type: {}", GetDDGITextureTypeName(m_importOptions.AssetType));
+			CD_INFO("Import asset type: {}", GetIOAssetTypeName(m_importOptions.AssetType));
 		}
+
+#ifdef ENABLE_DDGI
 		else if (ImGui::Selectable("DDGI Model"))
 		{
 			m_importOptions.AssetType = IOAssetType::DDGIModel;
 			m_pImportFileBrowser->SetTitle("ImportAssets - DDGI Model");
 			m_pImportFileBrowser->Open();
 
-			CD_INFO("Import asset type: {}", GetDDGITextureTypeName(m_importOptions.AssetType));
+			CD_INFO("Import asset type: {}", GetIOAssetTypeName(m_importOptions.AssetType));
 		}
 		else if (ImGui::Selectable("Light from json"))
 		{
 			m_importOptions.AssetType = IOAssetType::Light;
 			m_pImportFileBrowser->SetTitle("ImportAssets - Light");
 			m_pImportFileBrowser->Open();
-			CD_INFO("Import asset type: {}", GetDDGITextureTypeName(m_importOptions.AssetType));
+			CD_INFO("Import asset type: {}", GetIOAssetTypeName(m_importOptions.AssetType));
 		}
+#endif
 
 		ImGui::EndPopup();
 	}
@@ -399,7 +402,7 @@ void AssetBrowser::UpdateAssetFolderTree()
 			m_pExportFileBrowser->SetTitle("ExportAssets - SceneDatabase");
 			m_pExportFileBrowser->Open();
 
-			CD_INFO("Export asset type: {}", GetDDGITextureTypeName(m_exportOptions.AssetType));
+			CD_INFO("Export asset type: {}", GetIOAssetTypeName(m_exportOptions.AssetType));
 		}
 
 		ImGui::EndPopup();

--- a/Engine/Source/Editor/UILayers/AssetBrowser.h
+++ b/Engine/Source/Editor/UILayers/AssetBrowser.h
@@ -58,7 +58,7 @@ constexpr const char *IOAssetTypeName[] =
 static_assert(static_cast<int>(IOAssetType::Count) == sizeof(IOAssetTypeName) / sizeof(char *),
 	"IO asset type and names mismatch.");
 
-CD_FORCEINLINE const char *GetDDGITextureTypeName(IOAssetType type)
+CD_FORCEINLINE const char* GetIOAssetTypeName(IOAssetType type)
 {
 	return IOAssetTypeName[static_cast<size_t>(type)];
 }

--- a/Engine/Source/Editor/UILayers/AssetBrowser.h
+++ b/Engine/Source/Editor/UILayers/AssetBrowser.h
@@ -55,7 +55,7 @@ constexpr const char *IOAssetTypeName[] =
 	"Unknown",
 };
 
-static_assert(static_cast<int>(IOAssetType::Count) == sizeof(IOAssetTypeName) / sizeof(char *),
+static_assert(static_cast<int>(IOAssetType::Count) == sizeof(IOAssetTypeName) / sizeof(char*),
 	"IO asset type and names mismatch.");
 
 CD_FORCEINLINE const char* GetIOAssetTypeName(IOAssetType type)

--- a/Engine/Source/Editor/UILayers/Inspector.cpp
+++ b/Engine/Source/Editor/UILayers/Inspector.cpp
@@ -9,9 +9,11 @@ namespace details
 
 CD_FORCEINLINE bool EnableAtmosphericScattering()
 {
-	return engine::GraphicsBackend::OpenGL != engine::Path::GetGraphicsBackend() &&
-		engine::GraphicsBackend::OpenGLES != engine::Path::GetGraphicsBackend() &&
-		engine::GraphicsBackend::Vulkan != engine::Path::GetGraphicsBackend();
+	engine::GraphicsBackend backend = engine::Path::GetGraphicsBackend();
+
+	return engine::GraphicsBackend::Vulkan != backend
+		&& engine::GraphicsBackend::OpenGL != backend
+		&& engine::GraphicsBackend::OpenGLES != backend;
 }
 
 template<typename Component>

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
@@ -251,6 +251,8 @@ void MaterialComponent::Build()
 
 void MaterialComponent::SetSkyType(SkyType crtType)
 {
+	// SkyType::None is a special case which is not a uber option but means deactive Uber::IBL and Uber::ATM.
+
 	if (SkyType::Count == crtType || m_skyType == crtType)
 	{
 		return;

--- a/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
+++ b/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
@@ -48,12 +48,12 @@ void SceneWorld::CreatePBRMaterialType()
 	m_pPBRMaterialType->SetMaterialName("CD_PBR");
 
 	ShaderSchema shaderSchema(Path::GetBuiltinShaderInputPath("shaders/vs_PBR"), Path::GetBuiltinShaderInputPath("shaders/fs_PBR"));
-	shaderSchema.RegisterUberOption(Uber::ALBEDO_MAP);
-	shaderSchema.RegisterUberOption(Uber::NORMAL_MAP);
-	shaderSchema.RegisterUberOption(Uber::ORM_MAP);
-	shaderSchema.RegisterUberOption(Uber::EMISSIVE_MAP);
-	shaderSchema.RegisterUberOption(Uber::IBL);
-	shaderSchema.RegisterUberOption(Uber::ATM);
+	shaderSchema.AddUberOption(Uber::ALBEDO_MAP);
+	shaderSchema.AddUberOption(Uber::NORMAL_MAP);
+	shaderSchema.AddUberOption(Uber::ORM_MAP);
+	shaderSchema.AddUberOption(Uber::IBL);
+	shaderSchema.AddUberOption(Uber::ATM);
+	shaderSchema.AddUberOption(Uber::EMISSIVE_MAP);
 	shaderSchema.SetConflictOptions(Uber::ATM, Uber::IBL);
 	shaderSchema.Build();
 	m_pPBRMaterialType->SetShaderSchema(cd::MoveTemp(shaderSchema));
@@ -98,10 +98,10 @@ void SceneWorld::CreateDDGIMaterialType()
 	m_pDDGIMaterialType->SetMaterialName("CD_DDGI");
 
 	ShaderSchema shaderSchema(Path::GetBuiltinShaderInputPath("shaders/vs_DDGI"), Path::GetBuiltinShaderInputPath("shaders/fs_DDGI"));
-	shaderSchema.RegisterUberOption(Uber::ALBEDO_MAP);
-	shaderSchema.RegisterUberOption(Uber::NORMAL_MAP);
-	shaderSchema.RegisterUberOption(Uber::ORM_MAP);
-	shaderSchema.RegisterUberOption(Uber::EMISSIVE_MAP);
+	shaderSchema.AddUberOption(Uber::ALBEDO_MAP);
+	shaderSchema.AddUberOption(Uber::NORMAL_MAP);
+	shaderSchema.AddUberOption(Uber::ORM_MAP);
+	shaderSchema.AddUberOption(Uber::EMISSIVE_MAP);
 	shaderSchema.Build();
 	m_pDDGIMaterialType->SetShaderSchema(cd::MoveTemp(shaderSchema));
 

--- a/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
+++ b/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
@@ -54,6 +54,7 @@ void SceneWorld::CreatePBRMaterialType()
 	shaderSchema.RegisterUberOption(Uber::EMISSIVE_MAP);
 	shaderSchema.RegisterUberOption(Uber::IBL);
 	shaderSchema.RegisterUberOption(Uber::ATM);
+	shaderSchema.Build();
 	m_pPBRMaterialType->SetShaderSchema(cd::MoveTemp(shaderSchema));
 
 	cd::VertexFormat pbrVertexFormat;
@@ -100,7 +101,7 @@ void SceneWorld::CreateDDGIMaterialType()
 	shaderSchema.RegisterUberOption(Uber::NORMAL_MAP);
 	shaderSchema.RegisterUberOption(Uber::ORM_MAP);
 	shaderSchema.RegisterUberOption(Uber::EMISSIVE_MAP);
-	// shaderSchema.RegisterUberOption(Uber::DDGI);
+	shaderSchema.Build();
 	m_pDDGIMaterialType->SetShaderSchema(cd::MoveTemp(shaderSchema));
 
 	cd::VertexFormat ddgiVertexFormat;

--- a/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
+++ b/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
@@ -54,6 +54,7 @@ void SceneWorld::CreatePBRMaterialType()
 	shaderSchema.RegisterUberOption(Uber::EMISSIVE_MAP);
 	shaderSchema.RegisterUberOption(Uber::IBL);
 	shaderSchema.RegisterUberOption(Uber::ATM);
+	shaderSchema.SetConflictOptions(Uber::ATM, Uber::IBL);
 	shaderSchema.Build();
 	m_pPBRMaterialType->SetShaderSchema(cd::MoveTemp(shaderSchema));
 

--- a/Engine/Source/Runtime/Material/ShaderSchema.cpp
+++ b/Engine/Source/Runtime/Material/ShaderSchema.cpp
@@ -83,10 +83,9 @@ void ShaderSchema::Build()
 
 	CleanBuild();
 
-	// Use m_uberOptionsOffset to handle calling ShaderSchema::Build() multiple times.
-	for(auto itOpt = m_uberOptions.begin(); itOpt != m_uberOptions.end(); ++itOpt)
+	for(auto itOption = m_uberOptions.begin(); itOption != m_uberOptions.end(); ++itOption)
 	{
-		std::string newOption = GetUberName(*itOpt);
+		std::string newOption = GetUberName(*itOption);
 		std::vector<std::string> newOptions = { newOption };
 		const auto& conflictRange = m_conflictOptions.equal_range(newOption);
 
@@ -104,7 +103,7 @@ void ShaderSchema::Build()
 			}
 			if (!isConflict)
 			{
-				newOptions.push_back({ cobine + newOption });
+				newOptions.emplace_back(cobine + newOption);
 			}
 		}
 		m_uberCombines.insert(m_uberCombines.end(), newOptions.begin(), newOptions.end());
@@ -126,7 +125,8 @@ void ShaderSchema::CleanBuild()
 
 void ShaderSchema::CleanAll()
 {
-	m_uberCombines.clear();
+	CleanBuild();
+
 	m_uberOptions.clear();
 	m_conflictOptions.clear();
 }

--- a/Engine/Source/Runtime/Material/ShaderSchema.cpp
+++ b/Engine/Source/Runtime/Material/ShaderSchema.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cassert>
 #include <sstream>
-#include <string>
 
 namespace engine
 {
@@ -82,6 +81,7 @@ void ShaderSchema::Build()
 	}
 
 	CleanBuild();
+	m_isDirty = false;
 
 	for(auto itOption = m_uberOptions.begin(); itOption != m_uberOptions.end(); ++itOption)
 	{
@@ -120,12 +120,13 @@ void ShaderSchema::CleanBuild()
 {
 	m_uberCombines.clear();
 	m_compiledProgramHandles.clear();
-	m_isDirty = false;
+	m_isDirty = true;
 }
 
 void ShaderSchema::CleanAll()
 {
 	CleanBuild();
+	m_isDirty = false;
 
 	m_uberOptions.clear();
 	m_conflictOptions.clear();

--- a/Engine/Source/Runtime/Material/ShaderSchema.cpp
+++ b/Engine/Source/Runtime/Material/ShaderSchema.cpp
@@ -114,6 +114,10 @@ void ShaderSchema::Build()
 			m_compiledProgramHandles[StringCrc(newOpt).Value()] = InvalidProgramHandle;
 		}
 	}
+
+	// ShaderSchema also handle non-uber case.
+	m_uberCombines.emplace_back("");
+	m_compiledProgramHandles[DefaultUberShaderCrc.Value()] = InvalidProgramHandle;
 }
 
 void ShaderSchema::CleanBuild()

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -61,8 +61,9 @@ public:
 	const char* GetFragmentShaderPath() const { return m_fragmentShaderPath.c_str(); }
 
 	void AddUberOption(Uber uberOption);
-	// Call SetConflictOptions before call Build.
 	void SetConflictOptions(Uber a, Uber b);
+
+	// Calling "AddUberOption/SetConflictOptions and Build" after Build will cause unnecessary performance overhead.
 	void Build();
 	void CleanBuild();
 	void CleanAll();

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -60,15 +60,16 @@ public:
 	const char* GetVertexShaderPath() const { return m_vertexShaderPath.c_str(); }
 	const char* GetFragmentShaderPath() const { return m_fragmentShaderPath.c_str(); }
 
-	void SetConflictOptions(Uber a, Uber b);
 	void RegisterUberOption(Uber uberOption);
+	// Call SetConflictOptions before call Build.
+	void SetConflictOptions(Uber a, Uber b);
 	void Build();
-
-	bool IsUberOptionValid(StringCrc uberOption) const;
-	StringCrc GetOptionsCrc(const std::unordered_set<Uber>& options) const;
 
 	void SetCompiledProgram(StringCrc uberOption, uint16_t programHandle);
 	uint16_t GetCompiledProgram(StringCrc uberOption) const;
+
+	StringCrc GetOptionsCrc(const std::unordered_set<Uber>& options) const;
+	bool IsUberOptionsValid(StringCrc uberOption) const;
 
 	std::vector<Uber>& GetUberOptions() { return m_uberOptions; }
 	const std::vector<Uber>& GetUberOptions() const { return m_uberOptions; }
@@ -79,8 +80,8 @@ public:
 	std::unordered_map<uint32_t, uint16_t>& GetUberPrograms() { return m_compiledProgramHandles; }
 	const std::unordered_map<uint32_t, uint16_t>& GetUberPrograms() const { return m_compiledProgramHandles; }
 
-	std::unordered_map<Uber, Uber>& GetConflictOptions() { return m_conflictOptions; }
-	const std::unordered_map<Uber, Uber>& GetConflictOptions() const { return m_conflictOptions; }
+	std::unordered_multimap<std::string, std::string>& GetConflictOptions() { return m_conflictOptions; }
+	const std::unordered_multimap<std::string, std::string>& GetConflictOptions() const { return m_conflictOptions; }
 
 	// TODO : More generic.
 	void AddUberOptionVSBlob(ShaderBlob shaderBlob);
@@ -93,15 +94,16 @@ private:
 	std::string m_fragmentShaderPath;
 
 	bool m_isDirty;
-	size_t m_uberOptionsOfrfset;
+	size_t m_uberOptionsOffset;
 	// Registration order of options. 
 	std::vector<Uber> m_uberOptions;
 	// Parameters to compile shaders.
 	std::vector<std::string> m_uberCombines;
+
 	// Key: StringCrc(option combine), Value: shader handle.
 	std::unordered_map<uint32_t, uint16_t> m_compiledProgramHandles;
 	// Record options that will not be active at the same time to skip permutation.
-	std::unordered_map<Uber, Uber> m_conflictOptions;
+	std::unordered_multimap<std::string, std::string> m_conflictOptions;
 
 	std::unique_ptr<ShaderBlob> m_pVSBlob;
 	std::map<uint32_t, std::unique_ptr<ShaderBlob>> m_uberOptionToFSBlobs;

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -1,4 +1,4 @@
-#pragma once
+﻿#pragma once
 
 #include "Core/StringCrc.h"
 
@@ -6,6 +6,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -59,8 +60,9 @@ public:
 	const char* GetVertexShaderPath() const { return m_vertexShaderPath.c_str(); }
 	const char* GetFragmentShaderPath() const { return m_fragmentShaderPath.c_str(); }
 
-	// This option will combien with every exists combination.
+	void SetConflictOptions(Uber a, Uber b);
 	void RegisterUberOption(Uber uberOption);
+	void Build();
 
 	bool IsUberOptionValid(StringCrc uberOption) const;
 	StringCrc GetOptionsCrc(const std::unordered_set<Uber>& options) const;
@@ -68,9 +70,17 @@ public:
 	void SetCompiledProgram(StringCrc uberOption, uint16_t programHandle);
 	uint16_t GetCompiledProgram(StringCrc uberOption) const;
 
+	std::vector<Uber>& GetUberOptions() { return m_uberOptions; }
 	const std::vector<Uber>& GetUberOptions() const { return m_uberOptions; }
+
+	std::vector<std::string>& GetUberCombines() { return m_uberCombines; }
 	const std::vector<std::string>& GetUberCombines() const { return m_uberCombines; }
-	const std::map<uint32_t, uint16_t>& GetUberPrograms() const { return m_compiledProgramHandles; }
+
+	std::unordered_map<uint32_t, uint16_t>& GetUberPrograms() { return m_compiledProgramHandles; }
+	const std::unordered_map<uint32_t, uint16_t>& GetUberPrograms() const { return m_compiledProgramHandles; }
+
+	std::unordered_map<Uber, Uber>& GetConflictOptions() { return m_conflictOptions; }
+	const std::unordered_map<Uber, Uber>& GetConflictOptions() const { return m_conflictOptions; }
 
 	// TODO : More generic.
 	void AddUberOptionVSBlob(ShaderBlob shaderBlob);
@@ -82,12 +92,16 @@ private:
 	std::string m_vertexShaderPath;
 	std::string m_fragmentShaderPath;
 
+	bool m_isDirty;
+	size_t m_uberOptionsOfrfset;
 	// Registration order of options. 
 	std::vector<Uber> m_uberOptions;
 	// Parameters to compile shaders.
 	std::vector<std::string> m_uberCombines;
 	// Key: StringCrc(option combine), Value: shader handle.
-	std::map<uint32_t, uint16_t> m_compiledProgramHandles;
+	std::unordered_map<uint32_t, uint16_t> m_compiledProgramHandles;
+	// Record options that will not be active at the same time to skip permutation.
+	std::unordered_map<Uber, Uber> m_conflictOptions;
 
 	std::unique_ptr<ShaderBlob> m_pVSBlob;
 	std::map<uint32_t, std::unique_ptr<ShaderBlob>> m_uberOptionToFSBlobs;

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -60,10 +60,12 @@ public:
 	const char* GetVertexShaderPath() const { return m_vertexShaderPath.c_str(); }
 	const char* GetFragmentShaderPath() const { return m_fragmentShaderPath.c_str(); }
 
-	void RegisterUberOption(Uber uberOption);
+	void AddUberOption(Uber uberOption);
 	// Call SetConflictOptions before call Build.
 	void SetConflictOptions(Uber a, Uber b);
 	void Build();
+	void CleanBuild();
+	void CleanAll();
 
 	void SetCompiledProgram(StringCrc uberOption, uint16_t programHandle);
 	uint16_t GetCompiledProgram(StringCrc uberOption) const;
@@ -94,16 +96,15 @@ private:
 	std::string m_fragmentShaderPath;
 
 	bool m_isDirty;
-	size_t m_uberOptionsOffset;
 	// Registration order of options. 
 	std::vector<Uber> m_uberOptions;
 	// Parameters to compile shaders.
 	std::vector<std::string> m_uberCombines;
+	// Record options that will not be active at the same time to skip permutation.
+	std::unordered_multimap<std::string, std::string> m_conflictOptions;
 
 	// Key: StringCrc(option combine), Value: shader handle.
 	std::unordered_map<uint32_t, uint16_t> m_compiledProgramHandles;
-	// Record options that will not be active at the same time to skip permutation.
-	std::unordered_multimap<std::string, std::string> m_conflictOptions;
 
 	std::unique_ptr<ShaderBlob> m_pVSBlob;
 	std::map<uint32_t, std::unique_ptr<ShaderBlob>> m_uberOptionToFSBlobs;

--- a/Engine/Source/Runtime/Material/ShaderSchema.h
+++ b/Engine/Source/Runtime/Material/ShaderSchema.h
@@ -80,8 +80,8 @@ public:
 	std::vector<std::string>& GetUberCombines() { return m_uberCombines; }
 	const std::vector<std::string>& GetUberCombines() const { return m_uberCombines; }
 
-	std::unordered_map<uint32_t, uint16_t>& GetUberPrograms() { return m_compiledProgramHandles; }
-	const std::unordered_map<uint32_t, uint16_t>& GetUberPrograms() const { return m_compiledProgramHandles; }
+	std::map<uint32_t, uint16_t>& GetUberPrograms() { return m_compiledProgramHandles; }
+	const std::map<uint32_t, uint16_t>& GetUberPrograms() const { return m_compiledProgramHandles; }
 
 	std::unordered_multimap<std::string, std::string>& GetConflictOptions() { return m_conflictOptions; }
 	const std::unordered_multimap<std::string, std::string>& GetConflictOptions() const { return m_conflictOptions; }
@@ -105,7 +105,7 @@ private:
 	std::unordered_multimap<std::string, std::string> m_conflictOptions;
 
 	// Key: StringCrc(option combine), Value: shader handle.
-	std::unordered_map<uint32_t, uint16_t> m_compiledProgramHandles;
+	std::map<uint32_t, uint16_t> m_compiledProgramHandles;
 
 	std::unique_ptr<ShaderBlob> m_pVSBlob;
 	std::map<uint32_t, std::unique_ptr<ShaderBlob>> m_uberOptionToFSBlobs;

--- a/Engine/Source/Runtime/Rendering/RenderContext.cpp
+++ b/Engine/Source/Runtime/Rendering/RenderContext.cpp
@@ -372,10 +372,10 @@ bgfx::TextureHandle RenderContext::CreateTexture(const char* pName, uint16_t wid
 	return texture;
 }
 
-bgfx::TextureHandle RenderContext::UpdateTexture(const char *pName, uint16_t layer, uint8_t mip, uint16_t x, uint16_t y, uint16_t z, uint16_t width, uint16_t height, uint16_t depth, const void *data, uint32_t size)
+bgfx::TextureHandle RenderContext::UpdateTexture(const char* pName, uint16_t layer, uint8_t mip, uint16_t x, uint16_t y, uint16_t z, uint16_t width, uint16_t height, uint16_t depth, const void* data, uint32_t size)
 {
 	bgfx::TextureHandle handle = BGFX_INVALID_HANDLE;
-	const bgfx::Memory *mem = nullptr;
+	const bgfx::Memory* mem = nullptr;
 
 	StringCrc textureName(pName);
 	auto itTextureCache = m_textureHandleCaches.find(textureName.Value());

--- a/Engine/Source/Runtime/Resources/ShaderLoader.cpp
+++ b/Engine/Source/Runtime/Resources/ShaderLoader.cpp
@@ -19,7 +19,6 @@ void ShaderLoader::UploadUberShader(engine::MaterialType* pMaterialType)
 		std::string outputFSFilePath = engine::Path::GetShaderOutputPath(shaderSchema.GetFragmentShaderPath(), combine);
 		outputFSPathToUberOption[cd::MoveTemp(outputFSFilePath)] = engine::StringCrc(combine);
 	}
-	CD_ENGINE_INFO("Material type {0} have shader variant count : {1}.", pMaterialType->GetMaterialName(), shaderSchema.GetUberCombines().size());
 
 	// Vertex shader.
 	shaderSchema.AddUberOptionVSBlob(engine::ResourceLoader::LoadFile(outputVSFilePath.c_str()));


### PR DESCRIPTION
![image](https://github.com/CatDogEngine/CatDogEngine/assets/69386319/991bbc52-adbf-4fbe-813f-06c25481a93e)
![image](https://github.com/CatDogEngine/CatDogEngine/assets/69386319/7e715d65-83b6-4fdc-8e9e-e20477703d1e)
At least 16 uber shader variant reduced, and this number will increase as the total number of uber increases.
usage:
```cpp
	shaderSchema.AddUberOption(Uber::ALBEDO_MAP);
	shaderSchema.AddUberOption(Uber::NORMAL_MAP);
	shaderSchema.AddUberOption(Uber::ORM_MAP);
	shaderSchema.AddUberOption(Uber::EMISSIVE_MAP);
	shaderSchema.AddUberOption(Uber::IBL);
	shaderSchema.AddUberOption(Uber::ATM);
	shaderSchema.SetConflictOptions(Uber::ATM, Uber::IBL);
	shaderSchema.Build();
```