### PR TITLE
FileWatcher

### DIFF
--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -51,32 +51,6 @@
 //#include <format>
 #include <thread>
 
-// TODO : Some test call back function, delete these.
-void CreateCB(std::string path)
-{
-	CD_FATAL("Create : {0}.", cd::MoveTemp(path));
-}
-
-void ModifyCB(std::string path)
-{
-	CD_FATAL("Modify : {0}.", cd::MoveTemp(path));
-}
-
-void RenameOldCB(std::string path)
-{
-	CD_FATAL("RenameOld : {0}.", cd::MoveTemp(path));
-}
-
-void RenameNewCB(std::string path)
-{
-	CD_FATAL("RenameNew : {0}.", cd::MoveTemp(path));
-}
-
-void DeleteCB(std::string path)
-{
-	CD_FATAL("Delete : {0}.", cd::MoveTemp(path));
-}
-
 namespace editor
 {
 
@@ -130,14 +104,6 @@ void EditorApp::Init(engine::EngineInitArgs initArgs)
 	resourceThread.detach();
 
 	m_pFileWatcher = std::make_unique<FileWatcher>(CDENGINE_BUILTIN_SHADER_PATH);
-	m_pFileWatcher->EnableWatchSubTree();
-	// TODO : Test code.
-	m_pFileWatcher->SetFileAddedCallback(CreateCB);
-	m_pFileWatcher->SetFileModifiedCallback(ModifyCB);
-	m_pFileWatcher->SetFileRenamedOldCallback(RenameOldCB);
-	m_pFileWatcher->SetFileRenamedNewCallback(RenameNewCB);
-	m_pFileWatcher->SetFileRemovedCallback(DeleteCB);
-	m_pFileWatcher->Start();
 }
 
 void EditorApp::Shutdown()

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -51,6 +51,32 @@
 //#include <format>
 #include <thread>
 
+// TODO : Some test call back function, delete these.
+void CreateCB(std::string path)
+{
+	CD_FATAL("Create : {0}.", cd::MoveTemp(path));
+}
+
+void ModifyCB(std::string path)
+{
+	CD_FATAL("Modify : {0}.", cd::MoveTemp(path));
+}
+
+void RenameOldCB(std::string path)
+{
+	CD_FATAL("RenameOld : {0}.", cd::MoveTemp(path));
+}
+
+void RenameNewCB(std::string path)
+{
+	CD_FATAL("RenameNew : {0}.", cd::MoveTemp(path));
+}
+
+void DeleteCB(std::string path)
+{
+	CD_FATAL("Delete : {0}.", cd::MoveTemp(path));
+}
+
 namespace editor
 {
 
@@ -73,7 +99,6 @@ void EditorApp::Init(engine::EngineInitArgs initArgs)
 	{
 		CD_ERROR("Failed to open CSV file");
 	}
-
 
 	// Phase 1 - Splash
 	//		* Compile uber shader permutations automatically when initialization or detect changes
@@ -106,6 +131,12 @@ void EditorApp::Init(engine::EngineInitArgs initArgs)
 
 	m_pFileWatcher = std::make_unique<FileWatcher>(CDENGINE_BUILTIN_SHADER_PATH);
 	m_pFileWatcher->EnableWatchSubTree();
+	// TODO : Test code.
+	m_pFileWatcher->SetFileAddedCallback(CreateCB);
+	m_pFileWatcher->SetFileModifiedCallback(ModifyCB);
+	m_pFileWatcher->SetFileRenamedOldCallback(RenameOldCB);
+	m_pFileWatcher->SetFileRenamedNewCallback(RenameNewCB);
+	m_pFileWatcher->SetFileRemovedCallback(DeleteCB);
 	m_pFileWatcher->Start();
 }
 

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -26,6 +26,7 @@
 #include "Rendering/TerrainRenderer.h"
 #include "Rendering/WorldRenderer.h"
 #include "Rendering/ParticleRenderer.h"
+#include "Resources/FileWatcher.h"
 #include "Resources/ResourceBuilder.h"
 #include "Resources/ShaderBuilder.h"
 #include "Resources/ShaderLoader.h"
@@ -98,10 +99,14 @@ void EditorApp::Init(engine::EngineInitArgs initArgs)
 	m_pEditorImGuiContext->AddStaticLayer(std::make_unique<Splash>("Splash"));
 
 	std::thread resourceThread([]()
-		{
-			ResourceBuilder::Get().Update(true/*doPrintLog*/);
-		});
+	{
+		ResourceBuilder::Get().Update(true/*doPrintLog*/);
+	});
 	resourceThread.detach();
+
+	m_pFileWatcher = std::make_unique<FileWatcher>(CDENGINE_BUILTIN_SHADER_PATH);
+	m_pFileWatcher->EnableWatchSubTree();
+	m_pFileWatcher->Start();
 }
 
 void EditorApp::Shutdown()

--- a/Engine/Source/Editor/EditorApp.h
+++ b/Engine/Source/Editor/EditorApp.h
@@ -27,6 +27,7 @@ namespace editor
 {
 
 class EditorImGuiViewport;
+class FileWatcher;
 class SceneView;
 
 class EditorApp final : public engine::IApplication
@@ -100,6 +101,8 @@ private:
 
 	// Controllers for processing input events.
 	std::unique_ptr<engine::CameraController> m_pViewportCameraController;
+
+	std::unique_ptr<FileWatcher> m_pFileWatcher;
 };
 
 }

--- a/Engine/Source/Editor/Resources/FileWatcher.cpp
+++ b/Engine/Source/Editor/Resources/FileWatcher.cpp
@@ -1,0 +1,199 @@
+#include "FileWatcher.h"
+
+#include "Base/Template.h"
+#include "Log/Log.h"
+
+#include <filesystem>
+
+#ifdef _WIN32
+	#include <Windows.h>
+#else
+	// TODO : Remaining cross-platform code.
+#endif
+
+namespace editor
+{
+
+namespace
+{
+
+constexpr size_t BUFFER_SIZE = 1024;
+
+}
+
+FileWatcher::FileWatcher(std::string path)
+    : m_fileAddedCallback(nullptr), m_fileModifiedCallback(nullptr), m_fileRemovedCallback(nullptr),
+    m_fileRenamedOldCallBack(nullptr), m_fileRenamedNewCallBack(nullptr),
+    m_path(cd::MoveTemp(path)), m_isRunning(false), m_isWatchSubTree(false) {}
+
+FileWatcher::~FileWatcher()
+{
+    Stop();
+}
+
+void FileWatcher::SetFileAddedCallback(FileWatcherCallback callback)
+{
+    m_fileAddedCallback = callback;
+}
+
+void FileWatcher::SetFileModifiedCallback(FileWatcherCallback callback)
+{
+    m_fileModifiedCallback = callback;
+}
+
+void FileWatcher::SetFileRemovedCallback(FileWatcherCallback callback)
+{
+    m_fileRemovedCallback = callback;
+}
+
+void FileWatcher::SetFileRenamedOldCallback(FileWatcherCallback callback)
+{
+    m_fileRenamedOldCallBack = callback;
+}
+
+void FileWatcher::SetFileRenamedNewCallback(FileWatcherCallback callback)
+{
+    m_fileRenamedNewCallBack = callback;
+}
+
+void FileWatcher::Start()
+{
+    if (!std::filesystem::exists(m_path) || !std::filesystem::is_directory(m_path))
+    {
+        CD_ERROR("Unknown file watcher path!");
+        return;
+    }
+
+    if (m_isRunning)
+    {
+        CD_ERROR("File watcher is already running!");
+        return;
+    }
+
+    CD_INFO("Start watching \"{0}\", subtree {1}.", m_path, (m_isWatchSubTree ? "included" : "ignored"));
+
+    m_isRunning = true;
+    m_thread = std::thread(&FileWatcher::Watch, this);
+}
+
+void FileWatcher::Stop()
+{
+    if (m_isRunning)
+    {
+        m_isRunning = false;
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+    }
+}
+
+void FileWatcher::SetPath(std::string path)
+{
+    m_path = cd::MoveTemp(path);
+}
+
+void FileWatcher::Watch()
+{
+#ifdef _WIN32
+    HANDLE pathHandle = CreateFileA(m_path.c_str(), FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+    if (INVALID_HANDLE_VALUE == pathHandle)
+    {
+        CD_ERROR("FileWatcher create path handle failed!");
+        return;
+    }
+
+    char buffer[BUFFER_SIZE];
+    DWORD bytesReturned;
+
+    while (m_isRunning)
+    {
+        constexpr uint32_t WatchStatus = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_ATTRIBUTES | FILE_NOTIFY_CHANGE_SIZE | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_LAST_ACCESS | FILE_NOTIFY_CHANGE_CREATION | FILE_NOTIFY_CHANGE_SECURITY;
+
+        // TODO : Use LPOVERLAPPED
+        if (!ReadDirectoryChangesW(pathHandle, buffer, BUFFER_SIZE, m_isWatchSubTree, WatchStatus, &bytesReturned, nullptr, nullptr))
+        {
+            CD_ERROR("FileWatcher read directory changes failed!");
+            break;
+        }
+
+        FILE_NOTIFY_INFORMATION* pFileNotifyInfo = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(buffer);
+
+        while(true)
+        {
+            int fileNameSize = pFileNotifyInfo->FileNameLength / sizeof(WCHAR);
+            int utf8Size = WideCharToMultiByte(CP_UTF8, 0, pFileNotifyInfo->FileName, fileNameSize, nullptr, 0, nullptr, nullptr);
+            std::string fileName(utf8Size, 0);
+            WideCharToMultiByte(CP_UTF8, 0, pFileNotifyInfo->FileName, fileNameSize, fileName.data(), utf8Size, nullptr, nullptr);
+            std::string fullFilePath = (std::filesystem::path(m_path) / cd::MoveTemp(fileName)).generic_string();
+
+            DWORD fileAction = pFileNotifyInfo->Action;
+
+           switch (fileAction)
+           {
+               case FILE_ACTION_ADDED:
+                   CD_INFO("File added {0}", fullFilePath);
+                   if (m_fileAddedCallback)
+                   {
+                       m_fileAddedCallback(fullFilePath);
+                   }
+                   break;
+
+               case FILE_ACTION_MODIFIED:
+                   CD_INFO("File modified {0}", fullFilePath);
+                   if (m_fileModifiedCallback)
+                   {
+                       m_fileModifiedCallback(fullFilePath);
+                   }
+                   break;
+
+               case FILE_ACTION_REMOVED:
+                   CD_INFO("File removed {0}", fullFilePath);
+                   if (m_fileRemovedCallback)
+                   {
+                       m_fileRemovedCallback(fullFilePath);
+                   }
+                   break;
+
+               case FILE_ACTION_RENAMED_OLD_NAME:
+                   CD_INFO("File renamed old {0}", fullFilePath);
+                   if (m_fileRenamedOldCallBack)
+                   {
+                       m_fileRenamedOldCallBack(fullFilePath);
+                   }
+                   break;
+
+               case FILE_ACTION_RENAMED_NEW_NAME:
+                   CD_INFO("File renamed new {0}", fullFilePath);
+                   if (m_fileRenamedNewCallBack)
+                   {
+                       m_fileRenamedNewCallBack(fullFilePath);
+                   }
+                   break;
+
+               default:
+                   CD_ERROR("{0} unknown file whatcher status!", fullFilePath);
+                   break;
+           }
+
+           if (0 == pFileNotifyInfo->NextEntryOffset)
+           {
+               break;
+           }
+           
+           pFileNotifyInfo = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(reinterpret_cast<char*>(pFileNotifyInfo) + pFileNotifyInfo->NextEntryOffset);
+        }
+
+        memset(buffer, 0, bytesReturned);
+    }
+
+    CloseHandle(pathHandle);
+
+#else
+    // TODO : Remaining cross-platform code.
+#endif
+
+}
+
+}

--- a/Engine/Source/Editor/Resources/FileWatcher.h
+++ b/Engine/Source/Editor/Resources/FileWatcher.h
@@ -31,10 +31,8 @@ public:
     void Start();
     void Stop();
 
-    void SetPath(std::string path);
-    std::string& GetPath() { return m_path; }
     const std::string& GetPath() const { return m_path; }
-
+    
     const bool GetIsRunning() const { return m_isRunning; }
 
     void EnableWatchSubTree() { m_isWatchSubTree = true; }

--- a/Engine/Source/Editor/Resources/FileWatcher.h
+++ b/Engine/Source/Editor/Resources/FileWatcher.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <thread>
+
+namespace editor
+{
+
+class FileWatcher
+{
+private:
+    typedef std::function<void(std::string)> FileWatcherCallback;
+
+public:
+    FileWatcher(std::string path);
+    ~FileWatcher();
+
+    FileWatcher() = delete;
+    FileWatcher(const FileWatcher&) = delete;
+    FileWatcher& operator=(const FileWatcher&) = delete;
+    FileWatcher(FileWatcher&&) = delete;
+    FileWatcher& operator=(FileWatcher&&) = delete;
+
+    void SetFileAddedCallback(FileWatcherCallback callback);
+    void SetFileModifiedCallback(FileWatcherCallback callback);
+    void SetFileRemovedCallback(FileWatcherCallback callback);
+    void SetFileRenamedOldCallback(FileWatcherCallback callback);
+    void SetFileRenamedNewCallback(FileWatcherCallback callback);
+
+    void Start();
+    void Stop();
+
+    void SetPath(std::string path);
+    std::string& GetPath() { return m_path; }
+    const std::string& GetPath() const { return m_path; }
+
+    const bool GetIsRunning() const { return m_isRunning; }
+
+    void EnableWatchSubTree() { m_isWatchSubTree = true; }
+    void DisableWatchSubTree() { m_isWatchSubTree = false; }
+    const bool GetIsWatchSubTree() const { return m_isWatchSubTree; }
+
+private:
+    FileWatcherCallback m_fileAddedCallback;
+    FileWatcherCallback m_fileModifiedCallback;
+    FileWatcherCallback m_fileRemovedCallback;
+    FileWatcherCallback m_fileRenamedOldCallBack;
+    FileWatcherCallback m_fileRenamedNewCallBack;
+
+    std::string m_path;
+    bool m_isRunning;
+    bool m_isWatchSubTree;
+
+    std::thread m_thread;
+
+    void Watch();
+};
+
+}


### PR DESCRIPTION
Usage:
```cpp
void CreateCB(std::string path)
{
	CD_FATAL("Create : {0}.", cd::MoveTemp(path));
}

void ModifyCB(std::string path)
{
	CD_FATAL("Modify : {0}.", cd::MoveTemp(path));
}

void RenameOldCB(std::string path)
{
	CD_FATAL("RenameOld : {0}.", cd::MoveTemp(path));
}

void RenameNewCB(std::string path)
{
	CD_FATAL("RenameNew : {0}.", cd::MoveTemp(path));
}

void DeleteCB(std::string path)
{
	CD_FATAL("Delete : {0}.", cd::MoveTemp(path));
}
```
```cpp
m_pFileWatcher = std::make_unique<FileWatcher>(CDENGINE_BUILTIN_SHADER_PATH);
m_pFileWatcher->EnableWatchSubTree();
m_pFileWatcher->SetFileAddedCallback(CreateCB);
m_pFileWatcher->SetFileModifiedCallback(ModifyCB);
m_pFileWatcher->SetFileRenamedOldCallback(RenameOldCB);
m_pFileWatcher->SetFileRenamedNewCallback(RenameNewCB);
m_pFileWatcher->SetFileRemovedCallback(DeleteCB);
m_pFileWatcher->Start();
```
![image](https://github.com/CatDogEngine/CatDogEngine/assets/69386319/d6f54c85-9af4-4c68-9c03-c4a6f80ee9a1)
No Chinese support.