### PR TITLE
Shader hot compile and reload

### DIFF
--- a/Engine/BuiltInShaders/shaders/fs_PBR.sc
+++ b/Engine/BuiltInShaders/shaders/fs_PBR.sc
@@ -41,5 +41,6 @@ void main()
 	// Fragment Color
 	gl_FragData[0] = vec4(dirColor + envColor + emiColor, 1.0);
 	gl_FragData[1] = vec4(emiColor, 1.0);
+	
 	// Post-processing will be used in the last pass.
 }

--- a/Engine/BuiltInShaders/shaders/fs_PBR.sc
+++ b/Engine/BuiltInShaders/shaders/fs_PBR.sc
@@ -41,6 +41,5 @@ void main()
 	// Fragment Color
 	gl_FragData[0] = vec4(dirColor + envColor + emiColor, 1.0);
 	gl_FragData[1] = vec4(emiColor, 1.0);
-	//gl_FragData[0] = vec4(1.0, 1.0, 1.0, 1.0);
 	// Post-processing will be used in the last pass.
 }

--- a/Engine/BuiltInShaders/shaders/fs_PBR.sc
+++ b/Engine/BuiltInShaders/shaders/fs_PBR.sc
@@ -41,6 +41,6 @@ void main()
 	// Fragment Color
 	gl_FragData[0] = vec4(dirColor + envColor + emiColor, 1.0);
 	gl_FragData[1] = vec4(emiColor, 1.0);
-	
+	//gl_FragData[0] = vec4(1.0, 1.0, 1.0, 1.0);
 	// Post-processing will be used in the last pass.
 }

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -347,20 +347,12 @@ void EditorApp::InitDDGIEntity()
 
 void EditorApp::InitFileWatcher()
 {
-	constexpr const char* watchPath = CDENGINE_BUILTIN_SHADER_PATH "shaders/";
+	constexpr const char* pWatchPath = CDENGINE_BUILTIN_SHADER_PATH "shaders/";
 
 	m_pFileWatcher = std::make_unique<FileWatcher>();
 	m_pFileWatcher->SetRenderContext(m_pRenderContext.get());
 	m_pFileWatcher->SetWindow(GetMainWindow());
-	m_pFileWatcher->WatchShaders(watchPath);
-}
-
-void EditorApp::ShaderHotModifyDetec()
-{
-	if (true == m_crtInputFocus)
-	{
-		return;
-	}
+	m_pFileWatcher->WatchShaders(pWatchPath);
 }
 
 void EditorApp::UpdateMaterials()
@@ -380,19 +372,19 @@ void EditorApp::UpdateMaterials()
 		m_pRenderContext->CheckShaderProgram(programName, featuresCombine);
 
 		// Shader source files have been modified, need to re-compile existing variants.
-		if (true == m_crtInputFocus && false == m_preInputFocus)
+		if (m_crtInputFocus && !m_preInputFocus)
 		{
-			m_pRenderContext->CheckModifiedShaderProgram(programName, featuresCombine);
+			m_pRenderContext->OnShaderHotModified(programName, featuresCombine);
 		}
 	}
 
-	if (true == m_crtInputFocus && false == m_preInputFocus)
+	if (m_crtInputFocus && !m_preInputFocus)
 	{
 		m_pRenderContext->ClearModifiedProgramNameCrcs();
 	}
 }
 
-void EditorApp::RuntimeCompileAndLoadShaders()
+void EditorApp::CompileAndLoadShaders()
 {
 	bool doCompile = false;
 
@@ -679,7 +671,7 @@ bool EditorApp::Update(float deltaTime)
 		m_pEngineImGuiContext->Update(deltaTime);
 
 		UpdateMaterials();
-		RuntimeCompileAndLoadShaders();
+		CompileAndLoadShaders();
 
 		for (std::unique_ptr<engine::Renderer>& pRenderer : m_pEngineRenderers)
 		{

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -352,7 +352,7 @@ void EditorApp::InitFileWatcher()
 	FileWatchCallbackWrapper::SetRenderContext(m_pRenderContext.get());
 	FileWatchCallbackWrapper::SetWindow(GetMainWindow());
 	m_pFileWatcher = std::make_unique<FileWatcher>();
-	m_pFileWatcher->Watch(watchPath, FileWatchCallbackWrapper::Callback, 0, nullptr); // DMON_WATCHFLAGS_RECURSIVE
+	m_pFileWatcher->Watch(watchPath, FileWatchCallbackWrapper::Callback, 0, nullptr);
 }
 
 void EditorApp::ShaderHotModifyDetec()

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -350,9 +350,23 @@ void EditorApp::InitFileWatcher()
 	constexpr const char* pWatchPath = CDENGINE_BUILTIN_SHADER_PATH "shaders/";
 
 	m_pFileWatcher = std::make_unique<FileWatcher>();
-	m_pFileWatcher->SetRenderContext(m_pRenderContext.get());
-	m_pFileWatcher->SetWindow(GetMainWindow());
-	m_pFileWatcher->WatchShaders(pWatchPath);
+
+	FileWatchInfo info;
+	info.m_watchPath = pWatchPath;
+	info.m_isrecursive = false;
+	info.m_onModify.Bind<editor::EditorApp, &editor::EditorApp::OnShaderHotModifiedCallback>(this);
+	m_pFileWatcher->Watch(cd::MoveTemp(info));
+}
+
+void EditorApp::OnShaderHotModifiedCallback(const char* rootDir, const char* filePath)
+{
+	if (GetMainWindow()->GetInputFocus() || engine::Path::GetExtension(filePath) != ".sc")
+	{
+	    // Return when window get focus.
+	    // Return when a non-shader file is detected.
+	    return;
+	}
+	m_pRenderContext->CheckModifiedProgram(engine::Path::GetFileNameWithoutExtension(filePath));
 }
 
 void EditorApp::UpdateMaterials()

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -31,7 +31,7 @@
 #include "Rendering/TerrainRenderer.h"
 #include "Rendering/WorldRenderer.h"
 #include "Rendering/ParticleRenderer.h"
-#include "Resources/FileWatcher.hpp"
+#include "Resources/FileWatcher.h"
 #include "Resources/ResourceBuilder.h"
 #include "Resources/ShaderBuilder.h"
 #include "Scene/SceneDatabase.h"
@@ -349,10 +349,10 @@ void EditorApp::InitFileWatcher()
 {
 	constexpr const char* watchPath = CDENGINE_BUILTIN_SHADER_PATH "shaders/";
 
-	FileWatchCallbackWrapper::SetRenderContext(m_pRenderContext.get());
-	FileWatchCallbackWrapper::SetWindow(GetMainWindow());
 	m_pFileWatcher = std::make_unique<FileWatcher>();
-	m_pFileWatcher->Watch(watchPath, FileWatchCallbackWrapper::Callback, 0, nullptr);
+	m_pFileWatcher->SetRenderContext(m_pRenderContext.get());
+	m_pFileWatcher->SetWindow(GetMainWindow());
+	m_pFileWatcher->WatchShaders(watchPath);
 }
 
 void EditorApp::ShaderHotModifyDetec()

--- a/Engine/Source/Editor/EditorApp.h
+++ b/Engine/Source/Editor/EditorApp.h
@@ -83,9 +83,8 @@ private:
 #endif
 
 	void InitFileWatcher();
-	void ShaderHotModifyDetec();
 	void UpdateMaterials();
-	void RuntimeCompileAndLoadShaders();
+	void CompileAndLoadShaders();
 
 	bool m_crtInputFocus = true;
 	bool m_preInputFocus = true;

--- a/Engine/Source/Editor/EditorApp.h
+++ b/Engine/Source/Editor/EditorApp.h
@@ -83,6 +83,8 @@ private:
 #endif
 
 	void InitFileWatcher();
+	void OnShaderHotModifiedCallback(const char* rootDir, const char* filePath);
+
 	void UpdateMaterials();
 	void CompileAndLoadShaders();
 

--- a/Engine/Source/Editor/EditorApp.h
+++ b/Engine/Source/Editor/EditorApp.h
@@ -82,8 +82,13 @@ private:
 	void InitDDGIEntity();
 #endif
 
+	void InitFileWatcher();
+	void ShaderHotModifyDetec();
 	void UpdateMaterials();
-	void LazyCompileAndLoadShaders();
+	void RuntimeCompileAndLoadShaders();
+
+	bool m_crtInputFocus = true;
+	bool m_preInputFocus = true;
 
 	bool m_bInitEditor = false;
 	engine::EngineInitArgs m_initArgs;

--- a/Engine/Source/Editor/Resources/FileWatchInfo.h
+++ b/Engine/Source/Editor/Resources/FileWatchInfo.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Core/Delegates/Delegate.hpp"
+
+#include <string>
+
+namespace editor
+{
+
+class FileWatchInfo final
+{
+public:
+	FileWatchInfo() = default;
+	FileWatchInfo(const FileWatchInfo&) = default;
+	FileWatchInfo& operator=( const FileWatchInfo&) = default;
+	FileWatchInfo(FileWatchInfo&&) = default;
+	FileWatchInfo& operator=(FileWatchInfo&&) = default;
+	~FileWatchInfo() = default;
+
+	std::string m_watchPath = "";
+	bool m_isrecursive = false;
+
+	engine::Delegate<void(const char* rootDir, const char* filePath)> m_onCreate;
+	engine::Delegate<void(const char* rootDir, const char* filePath)> m_onDelete;
+	engine::Delegate<void(const char* rootDir, const char* filePath)> m_onModify;
+	engine::Delegate<void(const char* rootDir, const char* filePath, const char* oldFilePath)> m_onMove;
+};
+
+}

--- a/Engine/Source/Editor/Resources/FileWatcher.cpp
+++ b/Engine/Source/Editor/Resources/FileWatcher.cpp
@@ -17,9 +17,6 @@ namespace editor
 using WatchID = dmon_watch_id;
 using WatchAction = dmon_action;
 
-namespace
-{
-
 class ShaderHotModifyCallbackWrapper final
 {
 public:
@@ -54,10 +51,10 @@ public:
                 CD_TRACE("    Path : {0}", rootDir);
                 CD_TRACE("    Name : {0}", filePath);
 
-                if (m_pWindow->GetInputFocus() && engine::Path::GetExtension(filePath) != ".sc")
+                if (m_pWindow->GetInputFocus() || engine::Path::GetExtension(filePath) != ".sc")
                 {
-                    // Returns when the window does not get focus.
-                    // Returns when a non-shader file is detected.
+                    // Return when window get focus.
+                    // Return when a non-shader file is detected.
                     return;
                 }
 
@@ -83,8 +80,6 @@ public:
 
 engine::RenderContext* ShaderHotModifyCallbackWrapper::m_pRenderContext = nullptr;
 engine::Window* ShaderHotModifyCallbackWrapper::m_pWindow = nullptr;
-
-}
 
 FileWatcher::FileWatcher()
 {

--- a/Engine/Source/Editor/Resources/FileWatcher.cpp
+++ b/Engine/Source/Editor/Resources/FileWatcher.cpp
@@ -17,6 +17,9 @@ namespace editor
 using WatchID = dmon_watch_id;
 using WatchAction = dmon_action;
 
+namespace
+{
+
 class ShaderHotModifyCallbackWrapper final
 {
 public:
@@ -81,6 +84,8 @@ public:
 engine::RenderContext* ShaderHotModifyCallbackWrapper::m_pRenderContext = nullptr;
 engine::Window* ShaderHotModifyCallbackWrapper::m_pWindow = nullptr;
 
+}
+
 FileWatcher::FileWatcher()
 {
     Init();
@@ -91,14 +96,15 @@ FileWatcher::~FileWatcher()
     Deinit();
 }
 
-void FileWatcher::Init() const
+void FileWatcher::Init()
 {
     dmon_init();
 }
 
-void FileWatcher::Deinit() const
+void FileWatcher::Deinit()
 {
     dmon_deinit();
+    m_watchInfos.clear();
 }
 
 uint32_t FileWatcher::WatchShaders(const char* rootDir)
@@ -111,7 +117,7 @@ uint32_t FileWatcher::WatchShaders(const char* rootDir)
     CD_INFO("Start watching {0}", rootDir);
     CD_INFO("    Watch ID {0}", watchID.id);
     
-    m_witchInfos[watchID.id] = rootDir;
+    m_watchInfos[watchID.id] = rootDir;
 
     return watchID.id;
 }
@@ -119,17 +125,17 @@ uint32_t FileWatcher::WatchShaders(const char* rootDir)
 void FileWatcher::UnWatch(uint32_t watchID)
 {
     dmon_unwatch(WatchID{ watchID });
-    m_witchInfos.erase(watchID);
+    m_watchInfos.erase(watchID);
 }
 
-void FileWatcher::SetWitchInfos(std::map<uint32_t, const char*> witchInfos)
+void FileWatcher::SetWatchInfos(std::map<uint32_t, const char*> witchInfos)
 {
-    m_witchInfos = cd::MoveTemp(witchInfos);
+    m_watchInfos = cd::MoveTemp(witchInfos);
 }
 
 const char* FileWatcher::GetWatchingPath(uint32_t id) const
 {
-    return m_witchInfos.at(id);
+    return m_watchInfos.at(id);
 }
 
 }

--- a/Engine/Source/Editor/Resources/FileWatcher.h
+++ b/Engine/Source/Editor/Resources/FileWatcher.h
@@ -26,21 +26,22 @@ public:
     FileWatcher();
     ~FileWatcher();
 
-    void Init() const;
+    void Init();
     void SetRenderContext(engine::RenderContext* pRenderContext) { m_pRenderContext = pRenderContext; }
     void SetWindow(engine::Window* pWindow) { m_pWindow = pWindow; }
-    void Deinit() const;
+    void Deinit();
 
     uint32_t WatchShaders(const char* rootDir);
     void UnWatch(uint32_t watchID);
 
-    void SetWitchInfos(std::map<uint32_t, const char*>);
-    std::map<uint32_t, const char*>& GetWitchInfos() { return m_witchInfos; }
-    const std::map<uint32_t, const char*>& GetWitchInfos() const { return m_witchInfos; }
+    void SetWatchInfos(std::map<uint32_t, const char*>);
+    std::map<uint32_t, const char*>& GetWatchInfos() { return m_watchInfos; }
+    const std::map<uint32_t, const char*>& GetWitchInfos() const { return m_watchInfos; }
     const char* GetWatchingPath(uint32_t id) const;
 
 private:
-    std::map<uint32_t, const char*> m_witchInfos;
+    std::map<uint32_t, const char*> m_watchInfos;
+
     engine::RenderContext* m_pRenderContext;
     engine::Window* m_pWindow;
 };

--- a/Engine/Source/Editor/Resources/FileWatcher.h
+++ b/Engine/Source/Editor/Resources/FileWatcher.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+
+namespace engine
+{
+
+class RenderContext;
+class Window;
+
+}
+
+namespace editor
+{
+
+class FileWatcher final
+{
+
+public:
+    FileWatcher(const FileWatcher&) = delete;
+    FileWatcher& operator=(const FileWatcher&) = delete;
+    FileWatcher(FileWatcher&&) = delete;
+    FileWatcher& operator=(FileWatcher&&) = delete;
+
+    FileWatcher();
+    ~FileWatcher();
+
+    void Init() const;
+    void SetRenderContext(engine::RenderContext* pRenderContext) { m_pRenderContext = pRenderContext; }
+    void SetWindow(engine::Window* pWindow) { m_pWindow = pWindow; }
+    void Deinit() const;
+
+    uint32_t WatchShaders(const char* rootDir);
+    void UnWatch(uint32_t watchID);
+
+    void SetWitchInfos(std::map<uint32_t, const char*>);
+    std::map<uint32_t, const char*>& GetWitchInfos() { return m_witchInfos; }
+    const std::map<uint32_t, const char*>& GetWitchInfos() const { return m_witchInfos; }
+    const char* GetWatchingPath(uint32_t id) const;
+
+private:
+    std::map<uint32_t, const char*> m_witchInfos;
+    engine::RenderContext* m_pRenderContext;
+    engine::Window* m_pWindow;
+};
+
+}

--- a/Engine/Source/Editor/Resources/FileWatcher.h
+++ b/Engine/Source/Editor/Resources/FileWatcher.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Resources/FileWatchInfo.h"
+
 #include <cstdint>
 #include <map>
 
@@ -27,23 +29,20 @@ public:
     ~FileWatcher();
 
     void Init();
-    void SetRenderContext(engine::RenderContext* pRenderContext) { m_pRenderContext = pRenderContext; }
-    void SetWindow(engine::Window* pWindow) { m_pWindow = pWindow; }
     void Deinit();
 
-    uint32_t WatchShaders(const char* rootDir);
+    uint32_t Watch(FileWatchInfo info);
     void UnWatch(uint32_t watchID);
 
-    void SetWatchInfos(std::map<uint32_t, const char*>);
-    std::map<uint32_t, const char*>& GetWatchInfos() { return m_watchInfos; }
-    const std::map<uint32_t, const char*>& GetWitchInfos() const { return m_watchInfos; }
-    const char* GetWatchingPath(uint32_t id) const;
+    void SetWatchInfos(std::map<uint32_t, FileWatchInfo>);
+    std::map<uint32_t, FileWatchInfo>& GetWatchInfos() { return m_fileWatchInfos; }
+    const std::map<uint32_t, FileWatchInfo>& GetWatchInfos() const { return m_fileWatchInfos; }
+
+    const FileWatchInfo& GetWatchInfo(uint32_t id) const;
+    const std::string& GetWatchingPath(uint32_t id) const;
 
 private:
-    std::map<uint32_t, const char*> m_watchInfos;
-
-    engine::RenderContext* m_pRenderContext;
-    engine::Window* m_pWindow;
+    std::map<uint32_t, FileWatchInfo> m_fileWatchInfos;
 };
 
 }

--- a/Engine/Source/Editor/Resources/FileWatcher.hpp
+++ b/Engine/Source/Editor/Resources/FileWatcher.hpp
@@ -4,6 +4,9 @@
 #include <functional>
 
 #include "Log/Log.h"
+#include "Path/Path.h"
+#include "Rendering/RenderContext.h"
+#include "Window/Window.h"
 
 #define DMON_LOG_DEBUG(s) do { CD_INFO(s); } while(0)
 #define DMON_LOG_ERROR(s) do { CD_ERROR(s); assert(false); } while(0)
@@ -17,7 +20,7 @@ namespace editor
 using WatchID = dmon_watch_id;
 using WatchAction = dmon_action;
 
-class FileWatcher
+class FileWatcher final
 {
 
 public:
@@ -54,13 +57,94 @@ public:
             const char* oldName, void* user),
         uint32_t flags, void* userData)
     {
-        return dmon_watch(rootDir, callback, flags, userData);
+        WatchID watchID = dmon_watch(rootDir, callback, flags, userData);
+
+        CD_INFO("Start watching {0}", rootDir);
+        CD_INFO("    Watch ID {0}", watchID.id);
+
+        m_witchInfos[watchID.id] = rootDir;
+
+        return watchID;
     }
 
     void UnWatch(WatchID watchID)
     {
         dmon_unwatch(watchID);
     }
+
+    std::map<uint32_t, std::string> m_witchInfos;
 };
+
+class FileWatchCallbackWrapper final
+{
+public:
+    FileWatchCallbackWrapper() = default;
+    FileWatchCallbackWrapper(const FileWatchCallbackWrapper&) = delete;
+    FileWatchCallbackWrapper& operator=(const FileWatchCallbackWrapper&) = delete;
+    FileWatchCallbackWrapper(FileWatchCallbackWrapper&&) = delete;
+    FileWatchCallbackWrapper& operator=(FileWatchCallbackWrapper&&) = delete;
+    ~FileWatchCallbackWrapper() = default;
+
+    static void Callback(
+        WatchID id, WatchAction action,
+        const char* rootDir, const char* filePath,
+        const char* oldFilePath, void* user)
+    {
+        switch (action)
+        {
+            case DMON_ACTION_CREATE:
+                CD_TRACE("New file created");
+                CD_TRACE("    Path : {0}", rootDir);
+                CD_TRACE("    Name : {0}", filePath);
+                break;
+
+            case DMON_ACTION_DELETE:
+                CD_TRACE("File deleted");
+                CD_TRACE("    Path : {0}", rootDir);
+                CD_TRACE("    Name : {0}", filePath);
+                break;
+
+            case DMON_ACTION_MODIFY:
+                CD_TRACE("File Modified");
+                CD_TRACE("    Path : {0}", rootDir);
+                CD_TRACE("    Name : {0}", filePath);
+
+                if (m_pWindow->GetInputFocus())
+                {
+                    return;
+                }
+
+                m_pRenderContext->CheckModifiedProgram(engine::Path::GetFileNameWithoutExtension(filePath));
+
+                break;
+
+            case DMON_ACTION_MOVE:
+                CD_TRACE("File moved");
+                CD_TRACE("    Path : {0}", rootDir);
+                CD_TRACE("    Old Name : {0}", oldFilePath);
+                CD_TRACE("    New Name : {0}", filePath);
+                break;
+
+            default:
+                CD_WARN("Unknown WatchAction!");
+        }
+    }
+
+    static void SetRenderContext(engine::RenderContext* pRenderContext)
+    {
+        m_pRenderContext = pRenderContext;
+    }
+
+    static void SetWindow(engine::Window* pWindow)
+    {
+        m_pWindow = pWindow;
+    }
+
+    static engine::RenderContext* m_pRenderContext;
+    static engine::Window* m_pWindow;
+};
+
+engine::RenderContext* FileWatchCallbackWrapper::m_pRenderContext = nullptr;
+engine::Window* FileWatchCallbackWrapper::m_pWindow = nullptr;
 
 }

--- a/Engine/Source/Editor/Resources/FileWatcher.hpp
+++ b/Engine/Source/Editor/Resources/FileWatcher.hpp
@@ -109,7 +109,7 @@ public:
                 CD_TRACE("    Path : {0}", rootDir);
                 CD_TRACE("    Name : {0}", filePath);
 
-                if (m_pWindow->GetInputFocus())
+                if (m_pWindow->GetInputFocus() && engine::Path::GetExtension(filePath) != ".sc")
                 {
                     return;
                 }

--- a/Engine/Source/Runtime/Core/Delegates/Delegate.hpp
+++ b/Engine/Source/Runtime/Core/Delegates/Delegate.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <assert.h>
+#include <cassert>
 #include <functional>
 
 namespace engine
@@ -71,10 +71,12 @@ public:
 		m_pProxyFunc = &ConstMethodProxy<C, Function>;
 	}
 
+	bool Empty() const { return m_pProxyFunc == nullptr; }
+
 	RetVal Invoke(Args... args) const
 	{
-		assert(m_pProxyFunc != nullptr && "Cannot invoke unbound Delegate. Call Bind() first.");
-		return m_pProxyFunc(m_pInstance, std::forward<Args>(args)...);
+		//assert(m_pProxyFunc != nullptr && "Cannot invoke unbound Delegate. Call Bind() first.");
+		return m_pProxyFunc ? m_pProxyFunc(m_pInstance, std::forward<Args>(args)...) : RetVal{};
 	}
 
 private:

--- a/Engine/Source/Runtime/Core/Delegates/Delegate.hpp
+++ b/Engine/Source/Runtime/Core/Delegates/Delegate.hpp
@@ -76,7 +76,17 @@ public:
 	RetVal Invoke(Args... args) const
 	{
 		//assert(m_pProxyFunc != nullptr && "Cannot invoke unbound Delegate. Call Bind() first.");
-		return m_pProxyFunc ? m_pProxyFunc(m_pInstance, std::forward<Args>(args)...) : RetVal{};
+		if constexpr (std::is_same_v<RetVal, void>)
+		{
+			if (m_pProxyFunc != nullptr)
+			{
+				m_pProxyFunc(m_pInstance, std::forward<Args>(args)...);
+			}
+		}
+		else
+		{
+			return m_pProxyFunc != nullptr ? m_pProxyFunc(m_pInstance, std::forward<Args>(args)...) : RetVal{};
+		}
 	}
 
 private:

--- a/Engine/Source/Runtime/Core/Delegates/MulticastDelegate.hpp
+++ b/Engine/Source/Runtime/Core/Delegates/MulticastDelegate.hpp
@@ -49,15 +49,11 @@ public:
 		m_delegates.emplace_back(std::move(delegate));
 	}
 
+	bool Empty() const { return m_delegates.empty(); }
+
 	void Invoke(Args... args) const
 	{
-		if (m_delegates.empty())
-		{
-			// assert("MulticastDelegate doesn't bind any function calls.");
-			return;
-		}
-
-		for(const auto& delegate : m_delegates)
+		for (const auto& delegate : m_delegates)
 		{
 			delegate.Invoke(args...);
 		}

--- a/Engine/Source/Runtime/Path/Path.cpp
+++ b/Engine/Source/Runtime/Path/Path.cpp
@@ -142,12 +142,17 @@ bool Path::DirectoryExists(const char* pDirectoryPath)
 
 std::string Path::GetFileName(const char* pFilePath)
 {
-    return std::filesystem::path(pFilePath).filename().string();
+    return std::filesystem::path(pFilePath).filename().generic_string();
 }
 
 std::string Path::GetFileNameWithoutExtension(const char* pFilePath)
 {
-    return std::filesystem::path(pFilePath).stem().string();
+    return std::filesystem::path(pFilePath).stem().generic_string();
+}
+
+std::string Path::GetExtension(const char* pFilePath)
+{
+    return std::filesystem::path(pFilePath).extension().generic_string();
 }
 
 }

--- a/Engine/Source/Runtime/Path/Path.h
+++ b/Engine/Source/Runtime/Path/Path.h
@@ -33,6 +33,7 @@ public:
 	static bool DirectoryExists(const char* pDirectoryPath);
 	static std::string GetFileName(const char* pFilePath);
 	static std::string GetFileNameWithoutExtension(const char* pFilePath);
+	static std::string GetExtension(const char* pFilePath);
 
 private:
 	static std::filesystem::path GetEngineBuiltinShaderPath();

--- a/Engine/Source/Runtime/Rendering/RenderContext.cpp
+++ b/Engine/Source/Runtime/Rendering/RenderContext.cpp
@@ -201,12 +201,14 @@ bool RenderContext::CheckShaderProgram(const std::string& programName, const std
 		// there is no duplication of compilation behavior.
 		AddShaderCompileTask(ShaderCompileInfo{ programName, featuresCombine });
 		m_pShaderCollections->AddFeatureCombine(StringCrc{ programName }, featuresCombine);
+
 		return true;
 	}
+
 	return false;
 }
 
-bool RenderContext::CheckModifiedShaderProgram(const std::string& programName, const std::string& featuresCombine)
+bool RenderContext::OnShaderHotModified(const std::string& programName, const std::string& featuresCombine)
 {
 	assert(m_pShaderCollections->IsProgramValid(StringCrc{ programName }));
 
@@ -214,8 +216,10 @@ bool RenderContext::CheckModifiedShaderProgram(const std::string& programName, c
 	{
 		AddShaderCompileTask(engine::ShaderCompileInfo{ programName, featuresCombine });
 		DestroyShaderProgram(programName, featuresCombine);
+
 		return true;
 	}
+
 	return false;
 }
 
@@ -740,6 +744,7 @@ void RenderContext::DestoryShader(StringCrc resourceCrc)
 		bgfx::destroy(bgfx::ShaderHandle{ it->second });
 		m_shaderHandles.erase(it);
 	}
+
 	// Erase shader blob anyway.
 	m_shaderBlobs.erase(resourceCrc);
 }

--- a/Engine/Source/Runtime/Rendering/RenderContext.cpp
+++ b/Engine/Source/Runtime/Rendering/RenderContext.cpp
@@ -739,9 +739,9 @@ void RenderContext::DestoryShader(StringCrc resourceCrc)
 		assert(bgfx::isValid(bgfx::ShaderHandle{ it->second }));
 		bgfx::destroy(bgfx::ShaderHandle{ it->second });
 		m_shaderHandles.erase(it);
-
-		m_shaderBlobs.erase(resourceCrc);
 	}
+	// Erase shader blob anyway.
+	m_shaderBlobs.erase(resourceCrc);
 }
 
 void RenderContext::DestoryProgram(StringCrc resourceCrc)

--- a/Engine/Source/Runtime/Rendering/RenderContext.cpp
+++ b/Engine/Source/Runtime/Rendering/RenderContext.cpp
@@ -195,7 +195,7 @@ bool RenderContext::CheckShaderProgram(const std::string& programName, const std
 
 	if (m_shaderProgramHandles.find(StringCrc{ programName + featuresCombine }) == m_shaderProgramHandles.end())
 	{
-		// Its only represents that we do not hold the shader program GPU handle, 
+		// It only represents that we do not hold the shader program GPU handle, 
 		// whether the shader is compiled or not is unknown.
 		// The Combile Task will still be added to the queue and ResourceBuilder ensures that
 		// there is no duplication of compilation behavior.

--- a/Engine/Source/Runtime/Rendering/RenderContext.cpp
+++ b/Engine/Source/Runtime/Rendering/RenderContext.cpp
@@ -1,5 +1,6 @@
 #include "RenderContext.h"
 
+#include "Base/Template.h"
 #include "Log/Log.h"
 #include "Path/Path.h"
 #include "Renderer.h"
@@ -146,10 +147,10 @@ void RenderContext::BeginFrame()
 {
 }
 
-void RenderContext::Submit(uint16_t viewID, const std::string& programName, const std::string& featureCombine)
+void RenderContext::Submit(uint16_t viewID, const std::string& programName, const std::string& featuresCombine)
 {
-	assert(bgfx::isValid(GetShaderProgramHandle(programName, featureCombine)));
-	bgfx::submit(viewID, GetShaderProgramHandle(programName, featureCombine));
+	assert(bgfx::isValid(GetShaderProgramHandle(programName, featuresCombine)));
+	bgfx::submit(viewID, GetShaderProgramHandle(programName, featuresCombine));
 }
 
 void RenderContext::Dispatch(uint16_t viewID, const std::string& programName, uint32_t numX, uint32_t numY, uint32_t numZ)
@@ -190,26 +191,39 @@ void RenderContext::AddShaderFeature(StringCrc programNameCrc, std::string combi
 
 bool RenderContext::CheckShaderProgram(const std::string& programName, const std::string& featuresCombine)
 {
-	assert(m_pShaderCollections->IsProgramValid(StringCrc(programName)));
+	assert(m_pShaderCollections->IsProgramValid(StringCrc{ programName }));
 
-	if (!bgfx::isValid(GetShaderProgramHandle(programName, featuresCombine)))
+	if (m_shaderProgramHandles.find(StringCrc{ programName + featuresCombine }) == m_shaderProgramHandles.end())
 	{
 		// Its only represents that we do not hold the shader program GPU handle, 
 		// whether the shader is compiled or not is unknown.
 		// The Combile Task will still be added to the queue and ResourceBuilder ensures that
 		// there is no duplication of compilation behavior.
-		AddShaderCompileTask(ShaderCompileInfo(programName, featuresCombine));
-		m_pShaderCollections->AddFeatureCombine(StringCrc(programName), featuresCombine);
-		return false;
+		AddShaderCompileTask(ShaderCompileInfo{ programName, featuresCombine });
+		m_pShaderCollections->AddFeatureCombine(StringCrc{ programName }, featuresCombine);
+		return true;
 	}
-	return true;
+	return false;
+}
+
+bool RenderContext::CheckModifiedShaderProgram(const std::string& programName, const std::string& featuresCombine)
+{
+	assert(m_pShaderCollections->IsProgramValid(StringCrc{ programName }));
+
+	if (m_modifiedProgramNameCrcs.find(engine::StringCrc{ programName }) != m_modifiedProgramNameCrcs.end())
+	{
+		AddShaderCompileTask(engine::ShaderCompileInfo{ programName, featuresCombine });
+		DestroyShaderProgram(programName, featuresCombine);
+		return true;
+	}
+	return false;
 }
 
 void RenderContext::UploadShaderProgram(const std::string& programName, const std::string& featuresCombine)
 {
-	assert(m_pShaderCollections->IsProgramValid(StringCrc(programName)));
+	assert(m_pShaderCollections->IsProgramValid(StringCrc{ programName }));
 	
-	auto [vsName, fsName, csName] = IdentifyShaderTypes(m_pShaderCollections->GetShaders(StringCrc(programName)));
+	auto [vsName, fsName, csName] = IdentifyShaderTypes(m_pShaderCollections->GetShaders(StringCrc{ programName }));
 
 	if (featuresCombine.empty())
 	{
@@ -241,13 +255,26 @@ void RenderContext::UploadShaderProgram(const std::string& programName, const st
 	}
 }
 
+void RenderContext::DestroyShaderProgram(const std::string& programName, const std::string& featuresCombine)
+{
+	DestoryProgram(StringCrc{ programName + featuresCombine });
+
+	auto [vsName, fsName, csName] = IdentifyShaderTypes(m_pShaderCollections->GetShaders(StringCrc{ programName }));
+	StringCrc vsCrc{ vsName.data() };
+	StringCrc fsCrc{ fsName.data() + featuresCombine };
+	StringCrc csCrc{ csName.data() };
+
+	DestoryShader(vsCrc);
+	DestoryShader(fsCrc);
+	DestoryShader(csCrc);
+}
+
 void RenderContext::AddShaderCompileTask(ShaderCompileInfo info)
 {
-	const auto& it = std::find(m_shaderCompileTasks.begin(), m_shaderCompileTasks.end(), info);
-	if (it == m_shaderCompileTasks.end())
+	if (m_shaderCompileTasks.find(info) == m_shaderCompileTasks.end())
 	{
 		CD_ENGINE_INFO("Shader compile task added for {0} with shader features : [{1}]", info.m_programName, info.m_featuresCombine);
-		m_shaderCompileTasks.emplace_back(cd::MoveTemp(info));
+		m_shaderCompileTasks.insert(cd::MoveTemp(info));
 	}
 }
 
@@ -256,9 +283,32 @@ void RenderContext::ClearShaderCompileTasks()
 	m_shaderCompileTasks.clear();
 }
 
-void RenderContext::SetShaderCompileTasks(std::vector<ShaderCompileInfo> tasks)
+void RenderContext::SetShaderCompileTasks(std::set<ShaderCompileInfo> tasks)
 {
 	m_shaderCompileTasks = cd::MoveTemp(tasks);
+}
+
+void RenderContext::CheckModifiedProgram(std::string modifiedShaderName)
+{
+	// Find Shader Program name by Shader File Name.
+	// TODO : We could devise a mechanism like unity's meta file for recording dependencies on asset files,
+	// and perhaps both Program and Material information could be retrieved directly from the meta file.
+	for (const auto& [programName, shaderNames] : m_pShaderCollections->GetShaderPrograms())
+	{
+		for (const auto& shaderName : shaderNames)
+		{
+			if (shaderName == modifiedShaderName)
+			{
+				m_modifiedProgramNameCrcs.insert(programName);
+				break;
+			}
+		}
+	}
+}
+
+void RenderContext::ClearModifiedProgramNameCrcs()
+{
+	m_modifiedProgramNameCrcs.clear();
 }
 
 const RenderContext::ShaderBlob& RenderContext::AddShaderBlob(StringCrc shaderNameCrc, ShaderBlob blob)
@@ -278,14 +328,14 @@ const RenderContext::ShaderBlob& RenderContext::GetShaderBlob(StringCrc shaderNa
 	return *m_shaderBlobs.at(shaderNameCrc).get();
 }
 
-void RenderContext::SetShaderProgramHandle(const std::string& programName, bgfx::ProgramHandle handle, const std::string& featureCombine)
+void RenderContext::SetShaderProgramHandle(const std::string& programName, bgfx::ProgramHandle handle, const std::string& featuresCombine)
 {
-	m_shaderProgramHandles[StringCrc(programName + featureCombine)] = handle.idx;
+	m_shaderProgramHandles[StringCrc{ programName + featuresCombine }] = handle.idx;
 }
 
-bgfx::ProgramHandle RenderContext::GetShaderProgramHandle(const std::string& programName, const std::string& featureCombine) const
+bgfx::ProgramHandle RenderContext::GetShaderProgramHandle(const std::string& programName, const std::string& featuresCombine) const
 {
-	const auto& it = m_shaderProgramHandles.find(StringCrc(programName + featureCombine));
+	const auto& it = m_shaderProgramHandles.find(StringCrc{ programName + featuresCombine });
 	if (it != m_shaderProgramHandles.end())
 	{
 		return { it->second };
@@ -318,16 +368,16 @@ RenderTarget* RenderContext::CreateRenderTarget(StringCrc resourceCrc, std::uniq
 	return m_renderTargetCaches[resourceCrc].get();
 }
 
-bgfx::ShaderHandle RenderContext::CreateShader(const char* pShaderName)
+bgfx::ShaderHandle RenderContext::CreateShader(const char* pShaderName, const std::string& combine)
 {
-	StringCrc shaderNameCrc(pShaderName);
+	StringCrc shaderNameCrc{ pShaderName + combine };
 	auto itShaderCache = m_shaderHandles.find(shaderNameCrc);
 	if(itShaderCache != m_shaderHandles.end())
 	{
 		return { itShaderCache->second };
 	}
 
-	std::string shaderFileFullPath = Path::GetShaderOutputPath(pShaderName);
+	std::string shaderFileFullPath = Path::GetShaderOutputPath(pShaderName, combine);
 	const auto& shaderBlob = AddShaderBlob(shaderNameCrc, ResourceLoader::LoadFile(shaderFileFullPath.c_str()));
 	bgfx::ShaderHandle shaderHandle = bgfx::createShader(bgfx::makeRef(shaderBlob.data(), static_cast<uint32_t>(shaderBlob.size())));
 
@@ -342,7 +392,7 @@ bgfx::ShaderHandle RenderContext::CreateShader(const char* pShaderName)
 
 bgfx::ProgramHandle RenderContext::CreateProgram(const std::string& programName, const std::string& csName)
 {
-	StringCrc programNameCrc(programName);
+	StringCrc programNameCrc{ programName };
 	auto itProgram = m_shaderProgramHandles.find(programNameCrc);
 	if (itProgram != m_shaderProgramHandles.end())
 	{
@@ -358,9 +408,9 @@ bgfx::ProgramHandle RenderContext::CreateProgram(const std::string& programName,
 	return programHandle;
 }
 
-bgfx::ProgramHandle RenderContext::CreateProgram(const std::string& programName, const std::string& vsName, const std::string& fsName, const std::string& featureCombine)
+bgfx::ProgramHandle RenderContext::CreateProgram(const std::string& programName, const std::string& vsName, const std::string& fsName, const std::string& featuresCombine)
 {
-	StringCrc fullProgramNameCrc = StringCrc(programName + featureCombine);
+	StringCrc fullProgramNameCrc = StringCrc{ programName + featuresCombine };
 
 	const auto& it = m_shaderProgramHandles.find(fullProgramNameCrc);
 	if (it != m_shaderProgramHandles.end())
@@ -368,11 +418,8 @@ bgfx::ProgramHandle RenderContext::CreateProgram(const std::string& programName,
 		return { it->second };
 	}
 
-	std::string inputVSFilePath = engine::Path::GetBuiltinShaderInputPath(vsName.c_str());
-	std::string outputFSFilePath = engine::Path::GetShaderOutputPath(fsName.c_str(), featureCombine);
-
-	bgfx::ShaderHandle vsHandle = CreateShader(inputVSFilePath.c_str());
-	bgfx::ShaderHandle fsHandle = CreateShader(outputFSFilePath.c_str());
+	bgfx::ShaderHandle vsHandle = CreateShader(vsName.c_str());
+	bgfx::ShaderHandle fsHandle = CreateShader(fsName.c_str(), featuresCombine);
 	bgfx::ProgramHandle programHandle = bgfx::createProgram(vsHandle, fsHandle);
 
 	if (bgfx::isValid(programHandle))
@@ -385,7 +432,7 @@ bgfx::ProgramHandle RenderContext::CreateProgram(const std::string& programName,
 
 bgfx::TextureHandle RenderContext::CreateTexture(const char* pFilePath, uint64_t flags)
 {
-	StringCrc filePathCrc(pFilePath);
+	StringCrc filePathCrc{ pFilePath };
 	auto itTextureCache = m_textureHandleCaches.find(filePathCrc);
 	if (itTextureCache != m_textureHandleCaches.end())
 	{
@@ -467,7 +514,7 @@ bgfx::TextureHandle RenderContext::CreateTexture(const char* pFilePath, uint64_t
 
 bgfx::TextureHandle RenderContext::CreateTexture(const char* pName, uint16_t width, uint16_t height, uint16_t depth, bgfx::TextureFormat::Enum format, uint64_t flags, const void* data, uint32_t size)
 {
-	StringCrc textureNameCrc(pName);
+	StringCrc textureNameCrc{ pName };
 	auto itTextureCache = m_textureHandleCaches.find(textureNameCrc);
 	if(itTextureCache != m_textureHandleCaches.end())
 	{
@@ -509,7 +556,7 @@ bgfx::TextureHandle RenderContext::UpdateTexture(const char* pName, uint16_t lay
 	bgfx::TextureHandle handle = BGFX_INVALID_HANDLE;
 	const bgfx::Memory* mem = nullptr;
 
-	StringCrc textureNameCrc(pName);
+	StringCrc textureNameCrc{ pName };
 	auto itTextureCache = m_textureHandleCaches.find(textureNameCrc);
 	if (itTextureCache == m_textureHandleCaches.end())
 	{
@@ -537,7 +584,7 @@ bgfx::TextureHandle RenderContext::UpdateTexture(const char* pName, uint16_t lay
 
 bgfx::UniformHandle RenderContext::CreateUniform(const char* pName, bgfx::UniformType::Enum uniformType, uint16_t number)
 {
-	StringCrc uniformNameCrc(pName);
+	StringCrc uniformNameCrc{ pName };
 	auto itUniformCache = m_uniformHandleCaches.find(uniformNameCrc);
 	if (itUniformCache != m_uniformHandleCaches.end())
 	{
@@ -692,6 +739,8 @@ void RenderContext::DestoryShader(StringCrc resourceCrc)
 		assert(bgfx::isValid(bgfx::ShaderHandle{ it->second }));
 		bgfx::destroy(bgfx::ShaderHandle{ it->second });
 		m_shaderHandles.erase(it);
+
+		m_shaderBlobs.erase(resourceCrc);
 	}
 }
 

--- a/Engine/Source/Runtime/Rendering/RenderContext.h
+++ b/Engine/Source/Runtime/Rendering/RenderContext.h
@@ -68,7 +68,7 @@ public:
 	void AddShaderFeature(StringCrc programNameCrc, std::string combine);
 
 	bool CheckShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
-	bool CheckModifiedShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
+	bool OnShaderHotModified(const std::string& programName, const std::string& featuresCombine = "");
 	void UploadShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
 	void DestroyShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
 

--- a/Engine/Source/Runtime/Rendering/RenderContext.h
+++ b/Engine/Source/Runtime/Rendering/RenderContext.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <set>
 #include <tuple>
 #include <unordered_map>
 
@@ -44,7 +45,7 @@ public:
 	void Init(GraphicsBackend backend, void* hwnd = nullptr);
 	void OnResize(uint16_t width, uint16_t height);
 	void BeginFrame();
-	void Submit(uint16_t viewID, const std::string& programName, const std::string& featureCombine = "");
+	void Submit(uint16_t viewID, const std::string& programName, const std::string& featuresCombine = "");
 	void Dispatch(uint16_t viewID, const std::string& programName, uint32_t numX, uint32_t numY, uint32_t numZ);
 	void EndFrame();
 	void Shutdown();
@@ -67,13 +68,20 @@ public:
 	void AddShaderFeature(StringCrc programNameCrc, std::string combine);
 
 	bool CheckShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
+	bool CheckModifiedShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
 	void UploadShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
+	void DestroyShaderProgram(const std::string& programName, const std::string& featuresCombine = "");
 
 	void AddShaderCompileTask(ShaderCompileInfo info);
 	void ClearShaderCompileTasks();
-	void SetShaderCompileTasks(std::vector<ShaderCompileInfo> tasks);
-	std::vector<ShaderCompileInfo>& GetShaderCompileTasks() { return m_shaderCompileTasks; }
-	const std::vector<ShaderCompileInfo>& GetShaderCompileTasks() const { return m_shaderCompileTasks; }
+	void SetShaderCompileTasks(std::set<ShaderCompileInfo> tasks);
+	std::set<ShaderCompileInfo>& GetShaderCompileTasks() { return m_shaderCompileTasks; }
+	const std::set<ShaderCompileInfo>& GetShaderCompileTasks() const { return m_shaderCompileTasks; }
+
+	void CheckModifiedProgram(std::string modifiedShaderName);
+	void ClearModifiedProgramNameCrcs();
+	std::set<StringCrc>& GetModifiedProgramNameCrcs() { return m_modifiedProgramNameCrcs; }
+	const std::set<StringCrc>& GetModifiedProgramNameCrcs() const { return m_modifiedProgramNameCrcs; }
 
 	/////////////////////////////////////////////////////////////////////
 	// Shader blob apis
@@ -85,16 +93,16 @@ public:
 	// Resource related apis
 	/////////////////////////////////////////////////////////////////////
 
-	void SetShaderProgramHandle(const std::string& programName, bgfx::ProgramHandle handle, const std::string& featureCombine = "");
-	bgfx::ProgramHandle GetShaderProgramHandle(const std::string& programName, const std::string& featureCombine = "") const;
+	void SetShaderProgramHandle(const std::string& programName, bgfx::ProgramHandle handle, const std::string& featuresCombine = "");
+	bgfx::ProgramHandle GetShaderProgramHandle(const std::string& programName, const std::string& featuresCombine = "") const;
 
 	RenderTarget* CreateRenderTarget(StringCrc resourceCrc, uint16_t width, uint16_t height, std::vector<AttachmentDescriptor> attachmentDescs);
 	RenderTarget* CreateRenderTarget(StringCrc resourceCrc, uint16_t width, uint16_t height, void* pWindowHandle);
 	RenderTarget* CreateRenderTarget(StringCrc resourceCrc, std::unique_ptr<RenderTarget> pRenderTarget);
 
-	bgfx::ShaderHandle CreateShader(const char* filePath);
+	bgfx::ShaderHandle CreateShader(const char* filePath, const std::string& combine = "");
 	bgfx::ProgramHandle CreateProgram(const std::string& programName, const std::string& csName);
-	bgfx::ProgramHandle CreateProgram(const std::string& programName, const std::string& vsName, const std::string& fsName, const std::string& featureCombine = "");
+	bgfx::ProgramHandle CreateProgram(const std::string& programName, const std::string& vsName, const std::string& fsName, const std::string& featuresCombine = "");
 
 	bgfx::TextureHandle CreateTexture(const char* filePath, uint64_t flags = 0UL);
 	bgfx::TextureHandle CreateTexture(const char* pName, uint16_t width, uint16_t height, uint16_t depth, bgfx::TextureFormat::Enum format, uint64_t flags = 0UL, const void* data = nullptr, uint32_t size = 0);
@@ -141,7 +149,8 @@ private:
 	// Key : StringCrc(Shader name), Value : Shader binary data
 	std::unordered_map<StringCrc, std::unique_ptr<ShaderBlob>> m_shaderBlobs;
 
-	std::vector<ShaderCompileInfo> m_shaderCompileTasks;
+	std::set<ShaderCompileInfo> m_shaderCompileTasks;
+	std::set<StringCrc> m_modifiedProgramNameCrcs;
 };
 
 }

--- a/Engine/Source/Runtime/Rendering/ShaderCollections.cpp
+++ b/Engine/Source/Runtime/Rendering/ShaderCollections.cpp
@@ -14,53 +14,53 @@ void ShaderCollections::RegisterShaderProgram(StringCrc programNameCrc, std::ini
 		return;
 	}
 	
-	m_shaderPrograms[programNameCrc.Value()] = cd::MoveTemp(names);
+	m_shaderPrograms[programNameCrc] = cd::MoveTemp(names);
 }
 
 void ShaderCollections::AddFeatureCombine(StringCrc programNameCrc, std::string combine)
 {
 	assert(IsProgramValid(programNameCrc) && "Shader program does not exist!");
 
-	m_programFeatureCombines[programNameCrc.Value()].insert(cd::MoveTemp(combine));
+	m_programFeatureCombines[programNameCrc].insert(cd::MoveTemp(combine));
 }
 
 void ShaderCollections::DeleteFeatureCombine(StringCrc programNameCrc, std::string combine)
 {
 	assert(HasFeatureCombine(programNameCrc) && "Feature combine does not exist!");
 
-	m_programFeatureCombines[programNameCrc.Value()].erase(cd::MoveTemp(combine));
+	m_programFeatureCombines[programNameCrc].erase(cd::MoveTemp(combine));
 }
 
 void ShaderCollections::SetShaders(StringCrc programNameCrc, std::set<std::string> shaders)
 {
 	assert(IsProgramValid(programNameCrc) && "Shader program does not exist!");
 
-	m_shaderPrograms[programNameCrc.Value()] = cd::MoveTemp(shaders);
+	m_shaderPrograms[programNameCrc] = cd::MoveTemp(shaders);
 }
 
 void ShaderCollections::SetFeatureCombines(StringCrc programNameCrc, std::set<std::string> combine)
 {
 	assert(IsProgramValid(programNameCrc) && "Shader program does not exist!");
 
-	m_programFeatureCombines[programNameCrc.Value()] = cd::MoveTemp(combine);
+	m_programFeatureCombines[programNameCrc] = cd::MoveTemp(combine);
 }
 
 bool ShaderCollections::IsProgramValid(StringCrc programNameCrc) const
 {
-	return (m_shaderPrograms.find(programNameCrc.Value()) != m_shaderPrograms.end());
+	return (m_shaderPrograms.find(programNameCrc) != m_shaderPrograms.end());
 }
 
 bool ShaderCollections::HasFeatureCombine(StringCrc programNameCrc) const
 {
-	return (m_programFeatureCombines.find(programNameCrc.Value()) != m_programFeatureCombines.end());
+	return (m_programFeatureCombines.find(programNameCrc) != m_programFeatureCombines.end());
 }
 
-void ShaderCollections::SetShaderPrograms(std::map<uint32_t, std::set<std::string>> shaders)
+void ShaderCollections::SetShaderPrograms(std::map<StringCrc, std::set<std::string>> shaders)
 {
 	m_shaderPrograms = cd::MoveTemp(shaders);
 }
 
-void ShaderCollections::SetProgramFeatureCombines(std::map<uint32_t, std::set<std::string>> combines)
+void ShaderCollections::SetProgramFeatureCombines(std::map<StringCrc, std::set<std::string>> combines)
 {
 	m_programFeatureCombines = cd::MoveTemp(combines);
 }

--- a/Engine/Source/Runtime/Rendering/ShaderCollections.h
+++ b/Engine/Source/Runtime/Rendering/ShaderCollections.h
@@ -29,29 +29,29 @@ public:
 	void DeleteFeatureCombine(StringCrc programNameCrc, std::string combine);
 
 	void SetShaders(StringCrc programNameCrc, std::set<std::string> shaders);
-	std::set<std::string>& GetShaders(StringCrc programNameCrc) { return m_shaderPrograms[programNameCrc.Value()]; }
-	const std::set<std::string>& GetShaders(StringCrc programNameCrc) const { return m_shaderPrograms.at(programNameCrc.Value()); }
+	std::set<std::string>& GetShaders(StringCrc programNameCrc) { return m_shaderPrograms[programNameCrc]; }
+	const std::set<std::string>& GetShaders(StringCrc programNameCrc) const { return m_shaderPrograms.at(programNameCrc); }
 
 	void SetFeatureCombines(StringCrc programNameCrc, std::set<std::string> combine);
-	std::set<std::string>& GetFeatureCombines(StringCrc programNameCrc) { return m_programFeatureCombines[programNameCrc.Value()]; }
-	const std::set<std::string>& GetFeatureCombines(StringCrc programNameCrc) const { return m_programFeatureCombines.at(programNameCrc.Value()); }
+	std::set<std::string>& GetFeatureCombines(StringCrc programNameCrc) { return m_programFeatureCombines[programNameCrc]; }
+	const std::set<std::string>& GetFeatureCombines(StringCrc programNameCrc) const { return m_programFeatureCombines.at(programNameCrc); }
 
 	bool IsProgramValid(StringCrc programNameCrc) const;
 	bool HasFeatureCombine(StringCrc programNameCrc) const;
 
-	void SetShaderPrograms(std::map<uint32_t, std::set<std::string>> shaders);
-	std::map<uint32_t, std::set<std::string>>& GetShaderPrograms() { return m_shaderPrograms; }
-	const std::map<uint32_t, std::set<std::string>>& GetShaderPrograms() const { return m_shaderPrograms; }
+	void SetShaderPrograms(std::map<StringCrc, std::set<std::string>> shaders);
+	std::map<StringCrc, std::set<std::string>>& GetShaderPrograms() { return m_shaderPrograms; }
+	const std::map<StringCrc, std::set<std::string>>& GetShaderPrograms() const { return m_shaderPrograms; }
 
-	void SetProgramFeatureCombines(std::map<uint32_t, std::set<std::string>> combines);
-	std::map<uint32_t, std::set<std::string>>& GetProgramFeatureCombines() { return m_programFeatureCombines; }
-	const std::map<uint32_t, std::set<std::string>>& GetProgramFeatureCombiness() const { return m_programFeatureCombines; }
+	void SetProgramFeatureCombines(std::map<StringCrc, std::set<std::string>> combines);
+	std::map<StringCrc, std::set<std::string>>& GetProgramFeatureCombines() { return m_programFeatureCombines; }
+	const std::map<StringCrc, std::set<std::string>>& GetProgramFeatureCombiness() const { return m_programFeatureCombines; }
 
 private:
-	// Key : StringCrc(Program name), Value : Shader names
-	std::map<uint32_t, std::set<std::string>> m_shaderPrograms;
-	// Key : StringCrc(Program name), Value : Feature combines used as a parameter for compiling shaders
-	std::map<uint32_t, std::set<std::string>> m_programFeatureCombines;
+	// Key : Program name, Value : Shader names
+	std::map<StringCrc, std::set<std::string>> m_shaderPrograms;
+	// Key : Program name, Value : Feature combines used as a parameter for compiling shaders
+	std::map<StringCrc, std::set<std::string>> m_programFeatureCombines;
 };
 
 }

--- a/Engine/Source/Runtime/Rendering/ShaderCompileInfo.h
+++ b/Engine/Source/Runtime/Rendering/ShaderCompileInfo.h
@@ -26,6 +26,20 @@ public:
 	{
 		return (m_programName == other.m_programName) && (m_featuresCombine == other.m_featuresCombine);
 	}
+
+	bool operator<(const ShaderCompileInfo& other) const
+	{
+		if (m_programName < other.m_programName)
+		{
+			return true;
+		}
+		if (m_programName > other.m_programName)
+		{
+			return false;
+		}
+
+		return m_featuresCombine < other.m_featuresCombine;
+	}
 };
 
 }


### PR DESCRIPTION
Finally, we can modify the shader and apply the changes in real time while the editor is launched.

- The compilation of shader occurs when the editor window regains focus, so make sure that the syntax in shader is correct at this time.
- The watching directory is `CatDogEngine/Engine/BuiltInShaders/shaders`.
- No support for detecting changes in shader header files.

TODO:
We can't handle dependencies between resource files right now.