### PR TITLE
Use texture switch

### DIFF
--- a/Engine/BuiltInShaders/shaders/fs_PBR.sc
+++ b/Engine/BuiltInShaders/shaders/fs_PBR.sc
@@ -36,7 +36,7 @@ void main()
 	vec3 envColor = GetEnvironment(material, v_worldPos, viewDir, v_normal);
 	
 	// Emissive
-	vec3 emiColor = material.emissive * u_emissiveColor.xyz;
+	vec3 emiColor = material.emissive * vec3_splat(u_emissiveColor.x);
 	
 	// Fragment Color
 	gl_FragData[0] = vec4(dirColor + envColor + emiColor, 1.0);

--- a/Engine/BuiltInShaders/shaders/fs_PBR.sc
+++ b/Engine/BuiltInShaders/shaders/fs_PBR.sc
@@ -8,7 +8,7 @@ $input v_worldPos, v_normal, v_texcoord0, v_TBN
 #include "../common/LightSource.sh"
 #include "../common/Envirnoment.sh"
 
-uniform vec4 u_emissiveColor;
+uniform vec4 u_emissiveColorAndFactor;
 
 vec3 GetDirectional(Material material, vec3 worldPos, vec3 viewDir) {
 	vec3 diffuseBRDF = material.albedo * CD_INV_PI;
@@ -36,7 +36,7 @@ void main()
 	vec3 envColor = GetEnvironment(material, v_worldPos, viewDir, v_normal);
 	
 	// Emissive
-	vec3 emiColor = material.emissive * vec3_splat(u_emissiveColor.x);
+	vec3 emiColor = material.emissive * u_emissiveColorAndFactor.xyz * vec3_splat(u_emissiveColorAndFactor.w);
 	
 	// Fragment Color
 	gl_FragData[0] = vec4(dirColor + envColor + emiColor, 1.0);

--- a/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
+++ b/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
@@ -281,7 +281,7 @@ void ECWorldConsumer::AddMaterial(engine::Entity entity, const cd::Material* pMa
 	// TODO : Need pMaterial->GetVec3fProperty
 	// if (auto optOcclusion = pMaterial->GetVec3fProperty(cd::MaterialPropertyGroup::BaseColor, cd::MaterialProperty::Factor); optOcclusion.has_value())
 	// {
-	// 	materialComponent.SetFactor(cd::MaterialPropertyGroup::BaseColor, optOcclusion.value());
+	//     materialComponent.SetFactor(cd::MaterialPropertyGroup::BaseColor, optOcclusion.value());
 	// }
 	
 	if (auto optOcclusion = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::Occlusion, cd::MaterialProperty::Factor); optOcclusion.has_value())
@@ -326,7 +326,7 @@ void ECWorldConsumer::AddMaterial(engine::Entity entity, const cd::Material* pMa
 		if (!textureFileBlob.empty())
 		{
 			// TODO : Store TextureFileBlob multiple times, a temporary solution here.
-			//        Should use something like TextureResource to store it.
+			//        Should use something like TextureResource to avoid duplicate storage.
 			materialComponent.AddTextureFileBlob(type, pMaterial, *pTexture, cd::MoveTemp(textureFileBlob));
 			if (auto pPropertyGroup = materialComponent.GetPropertyGroup(type); pPropertyGroup)
 			{

--- a/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
+++ b/Engine/Source/Editor/ECWorld/ECWorldConsumer.cpp
@@ -7,6 +7,7 @@
 #include "Math/Transform.hpp"
 #include "Path/Path.h"
 #include "Rendering/RenderContext.h"
+#include "Rendering/ShaderFeature.h"
 #include "Resources/ResourceBuilder.h"
 #include "Resources/ResourceLoader.h"
 #include "Resources/ShaderBuilder.h"
@@ -14,30 +15,9 @@
 
 #include <algorithm>
 #include <filesystem>
-//#include <format>
 
 namespace editor
 {
-
-namespace Detail
-{
-
-const std::unordered_map<cd::MaterialTextureType, engine::ShaderFeature> materialTextureTypeToShaderFeature
-{
-	{ cd::MaterialTextureType::BaseColor, engine::ShaderFeature::ALBEDO_MAP },
-	{ cd::MaterialTextureType::Normal, engine::ShaderFeature::NORMAL_MAP },
-	{ cd::MaterialTextureType::Occlusion, engine::ShaderFeature::ORM_MAP },
-	{ cd::MaterialTextureType::Roughness, engine::ShaderFeature::ORM_MAP },
-	{ cd::MaterialTextureType::Metallic, engine::ShaderFeature::ORM_MAP },
-	{ cd::MaterialTextureType::Emissive, engine::ShaderFeature::EMISSIVE_MAP },
-};
-
-CD_FORCEINLINE bool IsMaterialTextureTypeValid(cd::MaterialTextureType type)
-{
-	return materialTextureTypeToShaderFeature.find(type) != materialTextureTypeToShaderFeature.end();
-}
-
-} // namespace Detail
 
 ECWorldConsumer::ECWorldConsumer(engine::SceneWorld* pSceneWorld, engine::RenderContext* pRenderContext) :
 	m_pSceneWorld(pSceneWorld), m_pRenderContext(pRenderContext)
@@ -259,7 +239,7 @@ void ECWorldConsumer::AddAnimation(engine::Entity entity, const cd::Animation& a
 void ECWorldConsumer::AddMaterial(engine::Entity entity, const cd::Material* pMaterial, engine::MaterialType* pMaterialType, const cd::SceneDatabase* pSceneDatabase)
 {
 	std::set<uint8_t> compiledTextureSlot;
-	std::map<std::string, const cd::Texture*> outputTexturePathToData;
+	std::vector<std::tuple<cd::MaterialTextureType, std::string, const cd::Texture*>> outputTypeToData;
 
 	engine::MaterialComponent& materialComponent = m_pSceneWorld->GetWorld()->CreateComponent<engine::MaterialComponent>(entity);
 	materialComponent.Init();
@@ -267,100 +247,98 @@ void ECWorldConsumer::AddMaterial(engine::Entity entity, const cd::Material* pMa
 	materialComponent.SetMaterialData(pMaterial);
 	materialComponent.ActivateShaderFeature(engine::GetSkyTypeShaderFeature(m_pSceneWorld->GetSkyComponent(m_pSceneWorld->GetSkyEntity())->GetSkyType()));
 
-	cd::Vec3f albedoColor(1.0f);
-	engine::ShaderSchema& shaderSchema = pMaterialType->GetShaderSchema();
-	if (pMaterial)
+	// Expected textures are ready to build. Add more optional texture data.
+	for (cd::MaterialTextureType optionalTextureType : pMaterialType->GetOptionalTextureTypes())
 	{
-		// Expected textures are ready to build. Add more optional texture data.
-		for (cd::MaterialTextureType optionalTextureType : pMaterialType->GetOptionalTextureTypes())
+		cd::TextureID textureID = pMaterial->GetTextureID(optionalTextureType);
+		if (!textureID.IsValid())
 		{
-			cd::TextureID textureID = pMaterial->GetTextureID(optionalTextureType);
-			if (!textureID.IsValid())
-			{
-				// TODO : Its ok to have a material factor instead of texture, remove factor case warning.
-				CD_WARN("Material {0} does not have optional texture type {1}!", pMaterial->GetName(),
-					nameof::nameof_enum(optionalTextureType));
-				continue;
-			}
-
-			std::optional<uint8_t> optTextureSlot = pMaterialType->GetTextureSlot(optionalTextureType);
-			if (!optTextureSlot.has_value())
-			{
-				CD_ERROR("Unknow texture {0} slot!", nameof::nameof_enum(optionalTextureType));
-				break;
-			}
-
-			if (Detail::IsMaterialTextureTypeValid(optionalTextureType))
-			{
-				materialComponent.ActivateShaderFeature(Detail::materialTextureTypeToShaderFeature.at(optionalTextureType));
-			}
-
-			uint8_t textureSlot = optTextureSlot.value();
-			const cd::Texture& optionalTexture = pSceneDatabase->GetTexture(textureID.Data());
-			std::string outputTexturePath = engine::Path::GetTextureOutputFilePath(optionalTexture.GetPath(), ".dds");
-			if (compiledTextureSlot.find(textureSlot) == compiledTextureSlot.end())
-			{
-				compiledTextureSlot.insert(textureSlot);
-				ResourceBuilder::Get().AddTextureBuildTask(optionalTexture.GetType(), optionalTexture.GetPath(), outputTexturePath.c_str());
-				outputTexturePathToData[cd::MoveTemp(outputTexturePath)] = &optionalTexture;
-			}
+			continue;
 		}
 
-		if (auto optMetallic = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::Metallic, cd::MaterialProperty::Factor); optMetallic.has_value())
+		std::optional<uint8_t> optTextureSlot = pMaterialType->GetTextureSlot(optionalTextureType);
+		if (!optTextureSlot.has_value())
 		{
-			materialComponent.SetMetallicFactor(optMetallic.value());
+			CD_ERROR("Unknow texture {0} slot!", nameof::nameof_enum(optionalTextureType));
+			break;
 		}
 
-		if (auto optRoughness = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::Roughness, cd::MaterialProperty::Factor); optRoughness.has_value())
+		uint8_t textureSlot = optTextureSlot.value();
+		const cd::Texture& optionalTexture = pSceneDatabase->GetTexture(textureID.Data());
+		std::string outputTexturePath = engine::Path::GetTextureOutputFilePath(optionalTexture.GetPath(), ".dds");
+		if (compiledTextureSlot.find(textureSlot) == compiledTextureSlot.end())
 		{
-			materialComponent.SetRoughnessFactor(optRoughness.value());
+			// TODO : Resource level
+			compiledTextureSlot.insert(textureSlot);
+			ResourceBuilder::Get().AddTextureBuildTask(optionalTextureType, optionalTexture.GetPath(), outputTexturePath.c_str());
 		}
-
-		if (auto optTwoSided = pMaterial->GetBoolProperty(cd::MaterialPropertyGroup::General, cd::MaterialProperty::TwoSided); optTwoSided.has_value())
-		{
-			materialComponent.SetTwoSided(optTwoSided.value());
-		}
-
-		if (auto optBlendMode = pMaterial->GetI32Property(cd::MaterialPropertyGroup::General, cd::MaterialProperty::BlendMode); optBlendMode.has_value())
-		{
-			cd::BlendMode blendMode = static_cast<cd::BlendMode>(optBlendMode.value());
-			if (cd::BlendMode::Mask == blendMode)
-			{
-				auto optAlphaTestValue = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::General, cd::MaterialProperty::OpacityMaskClipValue);
-				assert(optAlphaTestValue.has_value());
-
-				materialComponent.SetAlphaCutOff(optAlphaTestValue.value());
-			}
-
-			materialComponent.SetBlendMode(blendMode);
-		}
+		outputTypeToData.emplace_back(optionalTextureType, cd::MoveTemp(outputTexturePath), &optionalTexture);
 	}
-	else
+
+	// TODO : create material component before ResourceBuilder done.
+	// Assign a special color for loading resource status.
+	
+	// TODO : Need pMaterial->GetVec3fProperty
+	// if (auto optOcclusion = pMaterial->GetVec3fProperty(cd::MaterialPropertyGroup::BaseColor, cd::MaterialProperty::Factor); optOcclusion.has_value())
+	// {
+	// 	materialComponent.SetFactor(cd::MaterialPropertyGroup::BaseColor, optOcclusion.value());
+	// }
+	
+	if (auto optOcclusion = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::Occlusion, cd::MaterialProperty::Factor); optOcclusion.has_value())
 	{
-		albedoColor = cd::Vec3f(0.2f);
+		materialComponent.SetFactor(cd::MaterialPropertyGroup::Occlusion, optOcclusion.value());
+	}
+	if (auto optRoughness = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::Roughness, cd::MaterialProperty::Factor); optRoughness.has_value())
+	{
+		materialComponent.SetFactor(cd::MaterialPropertyGroup::Metallic, optRoughness.value());
+	}
+	if (auto optMetallic = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::Metallic, cd::MaterialProperty::Factor); optMetallic.has_value())
+	{
+		materialComponent.SetFactor(cd::MaterialPropertyGroup::Metallic, optMetallic.value());
+	}
+
+	if (auto optTwoSided = pMaterial->GetBoolProperty(cd::MaterialPropertyGroup::General, cd::MaterialProperty::TwoSided); optTwoSided.has_value())
+	{
+		materialComponent.SetTwoSided(optTwoSided.value());
+	}
+	if (auto optBlendMode = pMaterial->GetI32Property(cd::MaterialPropertyGroup::General, cd::MaterialProperty::BlendMode); optBlendMode.has_value())
+	{
+		cd::BlendMode blendMode = static_cast<cd::BlendMode>(optBlendMode.value());
+		if (cd::BlendMode::Mask == blendMode)
+		{
+			auto optAlphaTestValue = pMaterial->GetFloatProperty(cd::MaterialPropertyGroup::General, cd::MaterialProperty::OpacityMaskClipValue);
+			assert(optAlphaTestValue.has_value());
+
+			materialComponent.SetAlphaCutOff(optAlphaTestValue.value());
+		}
+
+		materialComponent.SetBlendMode(blendMode);
 	}
 
 	// TODO : ResourceBuilder will move to EditorApp::Update in the future.
 	// Now let's wait all resource build tasks done here.
 	ResourceBuilder::Get().Update();
 
-	// TODO : create material component before ResourceBuilder done.
-	// Assign a special color for loading resource status.
-	materialComponent.SetAlbedoColor(cd::MoveTemp(albedoColor));
-
 	// Textures.
-	for (const auto& [outputTextureFilePath, pTextureData] : outputTexturePathToData)
+	for (const auto& [type, path, pTexture] : outputTypeToData)
 	{
-		auto textureFileBlob = engine::ResourceLoader::LoadFile(outputTextureFilePath.c_str());
-		if(!textureFileBlob.empty())
+		auto textureFileBlob = engine::ResourceLoader::LoadFile(path.c_str());
+		if (!textureFileBlob.empty())
 		{
-			materialComponent.AddTextureFileBlob(pTextureData->GetType(), pMaterial, *pTextureData, cd::MoveTemp(textureFileBlob));
+			// TODO : Store TextureFileBlob multiple times, a temporary solution here.
+			//        Should use something like TextureResource to store it.
+			materialComponent.AddTextureFileBlob(type, pMaterial, *pTexture, cd::MoveTemp(textureFileBlob));
+			if (auto pPropertyGroup = materialComponent.GetPropertyGroup(type); pPropertyGroup)
+			{
+				pPropertyGroup->useTexture = true;
+				materialComponent.ActivateShaderFeature(engine::MaterialTextureTypeToShaderFeature.at(type));
+			}
 		}
 	}
 
 	materialComponent.Build();
 }
-/**/
+
 void ECWorldConsumer::AddMorphs(engine::Entity entity, const std::vector<cd::Morph>& morphs, const cd::Mesh* pMesh)
 {
 	engine::World* pWorld = m_pSceneWorld->GetWorld();

--- a/Engine/Source/Editor/EditorApp.cpp
+++ b/Engine/Source/Editor/EditorApp.cpp
@@ -395,6 +395,7 @@ void EditorApp::UpdateMaterials()
 		const std::string& programName = pMaterialComponent->GetShaderProgramName();
 		const std::string& featuresCombine = pMaterialComponent->GetFeaturesCombine();
 
+
 		// New shader feature added, need to compile new variants.
 		m_pRenderContext->CheckShaderProgram(entity, programName, featuresCombine);
 

--- a/Engine/Source/Editor/UILayers/AssetBrowser.cpp
+++ b/Engine/Source/Editor/UILayers/AssetBrowser.cpp
@@ -1063,13 +1063,13 @@ void AssetBrowser::ImportJson(const char* pFilePath)
 			float metallic = material["float@_Metallic"];
 			if (engine::MaterialComponent* pMaterialComponent = mapMaterialNameToMaterialData[name])
 			{
-				pMaterialComponent->SetAlbedoColor(GetVec3fFormString(color) / 255.0f);
-				pMaterialComponent->SetMetallicFactor(metallic);
-				pMaterialComponent->SetRoughnessFactor(1.0f - roughness);
-				if (pMaterialComponent->GetTextureInfo(cd::MaterialPropertyGroup::BaseColor))
+				pMaterialComponent->SetFactor(cd::MaterialPropertyGroup::BaseColor, GetVec3fFormString(color) / 255.0f);
+				pMaterialComponent->SetFactor(cd::MaterialPropertyGroup::Metallic, metallic);
+				pMaterialComponent->SetFactor(cd::MaterialPropertyGroup::Roughness, roughness);
+				if (auto pPropertyGroup = pMaterialComponent->GetPropertyGroup(cd::MaterialPropertyGroup::BaseColor); pPropertyGroup)
 				{
-					pMaterialComponent->GetTextureInfo(cd::MaterialPropertyGroup::BaseColor)->SetUVOffset(GetVec2fFormString(UVOffset));
-					pMaterialComponent->GetTextureInfo(cd::MaterialPropertyGroup::BaseColor)->SetUVScale(GetVec2fFormString(UVScale));
+					pPropertyGroup->textureInfo.SetUVOffset(GetVec2fFormString(UVOffset));
+					pPropertyGroup->textureInfo.SetUVScale(GetVec2fFormString(UVScale));
 				}
 			}
 			else

--- a/Engine/Source/Editor/UILayers/EntityList.cpp
+++ b/Engine/Source/Editor/UILayers/EntityList.cpp
@@ -63,7 +63,6 @@ void EntityList::AddEntity(engine::SceneWorld* pSceneWorld)
         auto& materialComponent = pWorld->CreateComponent<engine::MaterialComponent>(entity);
         materialComponent.Init();
         materialComponent.SetMaterialType(pMaterialType);
-        materialComponent.SetAlbedoColor(cd::Vec3f(0.2f));
         materialComponent.ActivateShaderFeature(engine::GetSkyTypeShaderFeature(pSceneWorld->GetSkyComponent(pSceneWorld->GetSkyEntity())->GetSkyType()));
         materialComponent.Build();
 
@@ -126,7 +125,6 @@ void EntityList::AddEntity(engine::SceneWorld* pSceneWorld)
         auto& materialComponent = pWorld->CreateComponent<engine::MaterialComponent>(entity);
         materialComponent.Init();
         materialComponent.SetMaterialType(pTerrainMaterialType);
-        materialComponent.SetAlbedoColor(cd::Vec3f(0.2f));
         materialComponent.SetTwoSided(true);
         materialComponent.ActivateShaderFeature(engine::GetSkyTypeShaderFeature(pSceneWorld->GetSkyComponent(pSceneWorld->GetSkyEntity())->GetSkyType()));
         materialComponent.Build();

--- a/Engine/Source/Editor/UILayers/Inspector.cpp
+++ b/Engine/Source/Editor/UILayers/Inspector.cpp
@@ -261,6 +261,7 @@ void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pScene
 				}
 				else
 				{
+					// Draw a black square with text here.
 					ImVec2 currentPos = ImGui::GetCursorScreenPos();
 					ImGui::GetWindowDrawList()->AddRectFilled(currentPos, ImVec2{ currentPos.x + 64, currentPos.y + 64 }, IM_COL32(0, 0, 0, 255));
 					ImGui::SetCursorScreenPos(ImVec2{ currentPos.x, currentPos.y + 27});
@@ -273,6 +274,7 @@ void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pScene
 				ImGuiUtils::ImGuiVectorProperty("UV Offset", textureInfo.GetUVOffset(), cd::Unit::None, cd::Vec2f(0.0f), cd::Vec2f(1.0f), false, 0.01f);
 				ImGuiUtils::ImGuiVectorProperty("UV Scale", textureInfo.GetUVScale());
 				ImGuiUtils::ImGuiBoolProperty("Use texture", pPropertyGroup->useTexture);
+
 				if (pPropertyGroup->useTexture)
 				{
 					pMaterialComponent->ActivateShaderFeature(engine::MaterialTextureTypeToShaderFeature.at(textureType));

--- a/Engine/Source/Editor/UILayers/Inspector.cpp
+++ b/Engine/Source/Editor/UILayers/Inspector.cpp
@@ -239,62 +239,69 @@ void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pScene
 		for (int textureTypeValue = 0; textureTypeValue < nameof::enum_count<cd::MaterialTextureType>(); ++textureTypeValue)
 		{
 			auto textureType = static_cast<cd::MaterialTextureType>(textureTypeValue);
-			bool allowNoTextures = textureType == cd::MaterialTextureType::BaseColor ||
-				textureType == cd::MaterialTextureType::Emissive ||
-				textureType == cd::MaterialTextureType::Metallic ||
-				textureType == cd::MaterialTextureType::Roughness;
-
-			engine::MaterialComponent::TextureInfo* pTextureInfo = pMaterialComponent->GetTextureInfo(textureType);
-			bool canCreateTextureParameters = pTextureInfo || allowNoTextures;
-			if (canCreateTextureParameters)
+			auto pPropertyGroup = pMaterialComponent->GetPropertyGroup(textureType);
+			if (!pPropertyGroup)
 			{
-				const char* pTextureType = nameof::nameof_enum(static_cast<cd::MaterialTextureType>(textureTypeValue)).data();
-				bool isOpen = ImGui::CollapsingHeader(pTextureType, ImGuiTreeNodeFlags_AllowItemOverlap | ImGuiTreeNodeFlags_DefaultOpen);
-				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-				ImGui::Separator();
+				continue;
+			}
 
-				if (isOpen)
+			const char* pTextureType = nameof::nameof_enum(static_cast<cd::MaterialTextureType>(textureTypeValue)).data();
+			bool isOpen = ImGui::CollapsingHeader(pTextureType, ImGuiTreeNodeFlags_AllowItemOverlap | ImGuiTreeNodeFlags_DefaultOpen);
+			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+			ImGui::Separator();
+
+			if (isOpen)
+			{
+				ImGui::PushID(textureTypeValue);
+
+				auto& textureInfo = pPropertyGroup->textureInfo;
+				if (bgfx::kInvalidHandle != textureInfo.textureHandle)
 				{
-					ImGui::PushID(textureTypeValue);
-
-					if (cd::MaterialTextureType::BaseColor == textureType)
-					{
-						ImGuiUtils::ColorPickerProperty("AlbedoColor", pMaterialComponent->GetAlbedoColor());
-					}
-					else if (cd::MaterialTextureType::Metallic == textureType)
-					{
-						ImGuiUtils::ImGuiFloatProperty("Metalness", pMaterialComponent->GetMetallicFactor(), cd::Unit::None, 0.0f, 1.0f, false, 0.01f);
-					}
-					else if (cd::MaterialTextureType::Roughness == textureType)
-					{
-						ImGuiUtils::ImGuiFloatProperty("Roughness", pMaterialComponent->GetRoughnessFactor(), cd::Unit::None, 0.0f, 1.0f, false, 0.01f);
-					}
-					else if (cd::MaterialTextureType::Emissive == textureType)
-					{
-						float emissiveStrength = pMaterialComponent->GetEmissiveColor().x();
-						if (ImGuiUtils::ImGuiFloatProperty("Emissive Strength", emissiveStrength, cd::Unit::None, 0.0f, 1000.0f, false, 0.1f))
-						{
-							pMaterialComponent->SetEmissiveColor(cd::Vec3f(emissiveStrength));
-						}
-					}
-
-					if (pTextureInfo)
-					{
-						if (pTextureInfo->textureHandle != bgfx::kInvalidHandle)
-						{
-							ImGui::Image(reinterpret_cast<ImTextureID>(pTextureInfo->textureHandle), ImVec2(64, 64));
-						}
-
-						ImGuiUtils::ImGuiVectorProperty("UV Offset", pTextureInfo->GetUVOffset(), cd::Unit::None, cd::Vec2f(0.0f), cd::Vec2f(1.0f), false, 0.01f);
-						ImGuiUtils::ImGuiVectorProperty("UV Scale", pTextureInfo->GetUVScale());
-					}
-
-					ImGui::PopID();
+					ImGui::Image(reinterpret_cast<ImTextureID>(textureInfo.textureHandle), ImVec2(64, 64));
+				}
+				else
+				{
+					ImVec2 currentPos = ImGui::GetCursorScreenPos();
+					ImGui::GetWindowDrawList()->AddRectFilled(currentPos, ImVec2{ currentPos.x + 64, currentPos.y + 64 }, IM_COL32(0, 0, 0, 255));
+					ImGui::SetCursorScreenPos(ImVec2{ currentPos.x, currentPos.y + 27});
+					ImGui::SetWindowFontScale(0.55f);
+					ImGui::Text("No Resources");
+					ImGui::SetWindowFontScale(1.0f);
+					ImGui::SetCursorScreenPos(ImVec2{ currentPos.x, currentPos.y + 66});
 				}
 
-				ImGui::Separator();
-				ImGui::PopStyleVar();
+				ImGuiUtils::ImGuiVectorProperty("UV Offset", textureInfo.GetUVOffset(), cd::Unit::None, cd::Vec2f(0.0f), cd::Vec2f(1.0f), false, 0.01f);
+				ImGuiUtils::ImGuiVectorProperty("UV Scale", textureInfo.GetUVScale());
+				ImGuiUtils::ImGuiBoolProperty("Use texture", pPropertyGroup->useTexture);
+				if (pPropertyGroup->useTexture)
+				{
+					pMaterialComponent->ActivateShaderFeature(engine::MaterialTextureTypeToShaderFeature.at(textureType));
+				}
+				else
+				{
+					pMaterialComponent->DeactivateShaderFeature(engine::MaterialTextureTypeToShaderFeature.at(textureType));
+				}
+
+				if (cd::MaterialTextureType::BaseColor == textureType)
+				{
+					ImGuiUtils::ColorPickerProperty("Factor", *(pMaterialComponent->GetFactor<cd::Vec3f>(textureType)));
+				}
+				else if (cd::MaterialTextureType::Occlusion == textureType ||
+					cd::MaterialTextureType::Metallic == textureType ||
+					cd::MaterialTextureType::Roughness == textureType)
+				{
+					ImGuiUtils::ImGuiFloatProperty("Factor", *(pMaterialComponent->GetFactor<float>(textureType)), cd::Unit::None, 0.0f, 1.0f, false, 0.01f);
+				}
+				else if (cd::MaterialTextureType::Emissive == textureType)
+				{
+					ImGuiUtils::ImGuiFloatProperty("Factor", *(pMaterialComponent->GetFactor<float>(textureType)), cd::Unit::None, 0.0f, 10.0f, false, 0.1f);
+				}
+
+				ImGui::PopID();
 			}
+
+			ImGui::Separator();
+			ImGui::PopStyleVar();
 		}
 
 		// Shaders
@@ -597,8 +604,8 @@ void UpdateComponentWidget<engine::SkyComponent>(engine::SceneWorld* pSceneWorld
 
 				if (engine::SkyType::None == currentSkyType)
 				{
-					pMaterialComponent->DeactiveShaderFeature(engine::GetSkyTypeShaderFeature(engine::SkyType::AtmosphericScattering));
-					pMaterialComponent->DeactiveShaderFeature(engine::GetSkyTypeShaderFeature(engine::SkyType::SkyBox));
+					pMaterialComponent->DeactivateShaderFeature(engine::GetSkyTypeShaderFeature(engine::SkyType::AtmosphericScattering));
+					pMaterialComponent->DeactivateShaderFeature(engine::GetSkyTypeShaderFeature(engine::SkyType::SkyBox));
 				}
 				else
 				{

--- a/Engine/Source/Editor/UILayers/Inspector.cpp
+++ b/Engine/Source/Editor/UILayers/Inspector.cpp
@@ -271,7 +271,7 @@ void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pScene
 					ImGui::SetCursorScreenPos(ImVec2{ currentPos.x, currentPos.y + 66});
 				}
 
-				ImGuiUtils::ImGuiVectorProperty("UV Offset", textureInfo.GetUVOffset(), cd::Unit::None, cd::Vec2f(0.0f), cd::Vec2f(1.0f), false, 0.01f);
+				ImGuiUtils::ImGuiVectorProperty("UV Offset", textureInfo.GetUVOffset(), cd::Unit::None, cd::Vec2f::Zero(), cd::Vec2f::One(), false, 0.01f);
 				ImGuiUtils::ImGuiVectorProperty("UV Scale", textureInfo.GetUVScale());
 				ImGuiUtils::ImGuiBoolProperty("Use texture", pPropertyGroup->useTexture);
 
@@ -296,7 +296,12 @@ void UpdateComponentWidget<engine::MaterialComponent>(engine::SceneWorld* pScene
 				}
 				else if (cd::MaterialTextureType::Emissive == textureType)
 				{
-					ImGuiUtils::ImGuiFloatProperty("Factor", *(pMaterialComponent->GetFactor<float>(textureType)), cd::Unit::None, 0.0f, 10.0f, false, 0.1f);
+					cd::Vec4f& emissiveColorAndFactor = *(pMaterialComponent->GetFactor<cd::Vec4f>(textureType));
+					cd::Vec3f emissiveColor{ emissiveColorAndFactor.x(), emissiveColorAndFactor.y(), emissiveColorAndFactor.z() };
+					float emissiveFactor = emissiveColorAndFactor.w();
+					ImGuiUtils::ImGuiVectorProperty("Color", emissiveColor, cd::Unit::None, cd::Vec3f::Zero(), cd::Vec3f::One(), false, 0.01f);
+					ImGuiUtils::ImGuiFloatProperty("Factor", emissiveFactor, cd::Unit::None, 0.0f, 10.0f, false, 0.1f);
+					emissiveColorAndFactor = cd::Vec4f{ emissiveColor.x(), emissiveColor.y(), emissiveColor.z(), emissiveFactor };
 				}
 
 				ImGui::PopID();

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
@@ -125,7 +125,7 @@ void MaterialComponent::Init()
 	m_propertyGroups[cd::MaterialPropertyGroup::Metallic] = cd::MoveTemp(propertyGroup);
 
 	propertyGroup.useTexture = false;
-	propertyGroup.factor = 1.0f;
+	propertyGroup.factor = cd::Vec4f{ 1.0f, 1.0f, 1.0f, 1.0f };
 	m_propertyGroups[cd::MaterialPropertyGroup::Emissive] = cd::MoveTemp(propertyGroup);
 }
 

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.cpp
@@ -103,28 +103,52 @@ namespace engine
 void MaterialComponent::Init()
 {
 	Reset();
+	PropertyGroup propertyGroup;
+
+	propertyGroup.useTexture = false;
+	propertyGroup.factor = cd::Vec3f{ 1.0f, 1.0f, 1.0f };
+	m_propertyGroups[cd::MaterialPropertyGroup::BaseColor] = cd::MoveTemp(propertyGroup);
+
+	propertyGroup.useTexture = false;
+	m_propertyGroups[cd::MaterialPropertyGroup::Normal] = cd::MoveTemp(propertyGroup);
+
+	propertyGroup.useTexture = false;
+	propertyGroup.factor = 1.0f;
+	m_propertyGroups[cd::MaterialPropertyGroup::Occlusion] = cd::MoveTemp(propertyGroup);
+
+	propertyGroup.useTexture = false;
+	propertyGroup.factor = 0.9f;
+	m_propertyGroups[cd::MaterialPropertyGroup::Roughness] = cd::MoveTemp(propertyGroup);
+
+	propertyGroup.useTexture = false;
+	propertyGroup.factor = 0.1f;
+	m_propertyGroups[cd::MaterialPropertyGroup::Metallic] = cd::MoveTemp(propertyGroup);
+
+	propertyGroup.useTexture = false;
+	propertyGroup.factor = 1.0f;
+	m_propertyGroups[cd::MaterialPropertyGroup::Emissive] = cd::MoveTemp(propertyGroup);
 }
 
-MaterialComponent::TextureInfo* MaterialComponent::GetTextureInfo(cd::MaterialTextureType textureType)
+MaterialComponent::PropertyGroup* MaterialComponent::GetPropertyGroup(cd::MaterialPropertyGroup propertyGroup)
 {
-	auto itTextureInfo = m_textureResources.find(textureType);
-	if (itTextureInfo == m_textureResources.end())
+	auto it = m_propertyGroups.find(propertyGroup);
+	if (m_propertyGroups.end() == it)
 	{
 		return nullptr;
 	}
 
-	return &itTextureInfo->second;
+	return &(it->second);
 }
 
-const MaterialComponent::TextureInfo* MaterialComponent::GetTextureInfo(cd::MaterialTextureType textureType) const
+const MaterialComponent::PropertyGroup* MaterialComponent::GetPropertyGroup(cd::MaterialPropertyGroup propertyGroup) const
 {
-	auto itTextureInfo = m_textureResources.find(textureType);
-	if (itTextureInfo == m_textureResources.cend())
+	auto it = m_propertyGroups.find(propertyGroup);
+	if (m_propertyGroups.end() == it)
 	{
 		return nullptr;
 	}
 
-	return &itTextureInfo->second;
+	return &(it->second);
 }
 
 const std::string& MaterialComponent::GetShaderProgramName() const
@@ -149,7 +173,7 @@ void MaterialComponent::ActivateShaderFeature(ShaderFeature feature)
 	m_isShaderFeatureDirty = true;
 }
 
-void MaterialComponent::DeactiveShaderFeature(ShaderFeature feature)
+void MaterialComponent::DeactivateShaderFeature(ShaderFeature feature)
 {
 	m_shaderFeatures.erase(feature);
 
@@ -173,12 +197,7 @@ void MaterialComponent::Reset()
 {
 	m_pMaterialData = nullptr;
 	m_pMaterialType = nullptr;
-	m_shaderFeatures.clear();
 	m_name.clear();
-	m_albedoColor = cd::Vec3f::One();
-	m_emissiveColor = cd::Vec3f::One();
-	m_metallicFactor = 0.1f;
-	m_roughnessFactor = 0.9f;
 	m_twoSided = false;
 	m_blendMode = cd::BlendMode::Opaque;
 	m_alphaCutOff = 1.0f;
@@ -186,7 +205,7 @@ void MaterialComponent::Reset()
 	m_shaderFeatures.clear();
 	m_featureCombine.clear();
 	m_cacheTextureBlobs.clear();
-	m_textureResources.clear();
+	m_propertyGroups.clear();
 }
 
 void MaterialComponent::AddTextureBlob(cd::MaterialTextureType textureType, cd::TextureFormat textureFormat, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode,
@@ -197,8 +216,11 @@ void MaterialComponent::AddTextureBlob(cd::MaterialTextureType textureType, cd::
 	{
 		return;
 	}
+	
+	PropertyGroup& propertyGroup = m_propertyGroups[textureType];
+	propertyGroup.useTexture = true;
 
-	TextureInfo textureInfo = m_textureResources[textureType];
+	TextureInfo& textureInfo = propertyGroup.textureInfo;
 	textureInfo.slot = optTextureSlot.value();
 	textureInfo.width = width;
 	textureInfo.height = height;
@@ -209,7 +231,6 @@ void MaterialComponent::AddTextureBlob(cd::MaterialTextureType textureType, cd::
 	textureInfo.flag = GetBGFXTextureFlag(textureType, uMapMode, vMapMode);
 	textureInfo.uvOffset = cd::Vec2f::Zero();
 	textureInfo.uvScale = cd::Vec2f::One();
-	m_textureResources[textureType] = cd::MoveTemp(textureInfo);
 	
 	// TODO : generic CPU/GPU resource manager.
 	m_cacheTextureBlobs.emplace_back(cd::MoveTemp(textureBlob));
@@ -223,8 +244,11 @@ void MaterialComponent::AddTextureFileBlob(cd::MaterialTextureType textureType, 
 		return;
 	}
 
+	PropertyGroup& propertyGroup = m_propertyGroups[textureType];
+	propertyGroup.useTexture = true;
+
 	bimg::ImageContainer* pImageContainer = bimg::imageParse(GetResourceAllocator(), textureBlob.data(), static_cast<uint32_t>(textureBlob.size()));
-	TextureInfo textureInfo = m_textureResources[textureType];
+	TextureInfo& textureInfo = propertyGroup.textureInfo;
 	textureInfo.slot = optTextureSlot.value();
 	textureInfo.width = pImageContainer->m_width;
 	textureInfo.height = pImageContainer->m_height;
@@ -241,7 +265,6 @@ void MaterialComponent::AddTextureFileBlob(cd::MaterialTextureType textureType, 
 	{
 		textureInfo.uvOffset = optUVOffset.value();
 	}
-	m_textureResources[textureType] = cd::MoveTemp(textureInfo);
 }
 
 void MaterialComponent::Build()
@@ -251,8 +274,14 @@ void MaterialComponent::Build()
 		m_name = m_pMaterialData->GetName();
 	}
 	
-	for (auto& [textureType, textureInfo] : m_textureResources)
+	for (auto& [textureType, propertyGroup] : m_propertyGroups)
 	{
+		if (!propertyGroup.useTexture)
+		{
+			continue;
+		}
+
+		TextureInfo& textureInfo = propertyGroup.textureInfo;
 		textureInfo.textureHandle = BGFXCreateTexture(textureInfo.width, textureInfo.height, textureInfo.depth, false, textureInfo.mipCount > 1,
 			1, static_cast<bgfx::TextureFormat::Enum>(textureInfo.format), textureInfo.flag, textureInfo.data).idx;
 

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.h
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.h
@@ -73,7 +73,7 @@ public:
 	{
 		TextureInfo textureInfo;
 		bool useTexture;
-		std::variant<cd::Vec3f, float> factor;
+		std::variant<float, cd::Vec3f, cd::Vec4f> factor;
 	};
 
 public:
@@ -127,7 +127,7 @@ public:
 			return;
 		}
 
-		if (auto pValue = std::get_if<T>(&(it->second.factor)))
+		if (auto pValue = std::get_if<T>(&(it->second.factor)); pValue)
 		{
 			*pValue = cd::MoveTemp(factor);
 		}

--- a/Engine/Source/Runtime/ECWorld/MaterialComponent.h
+++ b/Engine/Source/Runtime/ECWorld/MaterialComponent.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <optional>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 namespace bgfx
@@ -44,17 +45,18 @@ public:
 	using TextureBlob = std::vector<std::byte>;
 	struct TextureInfo
 	{
-	public:
+		static constexpr uint16_t BGFXInvalidHandle = (1 << 16) - 1;
+
 		const bgfx::Memory* data;
 		uint64_t flag;
 		uint32_t width;
 		uint32_t height;
 		uint32_t depth;
 		cd::TextureFormat format;
-		cd::Vec2f uvOffset;
-		cd::Vec2f uvScale;
-		uint16_t samplerHandle;
-		uint16_t textureHandle;
+		cd::Vec2f uvOffset = cd::Vec2f::Zero();
+		cd::Vec2f uvScale = cd::Vec2f::One();
+		uint16_t samplerHandle = BGFXInvalidHandle;
+		uint16_t textureHandle = BGFXInvalidHandle;
 		uint8_t slot;
 		uint8_t mipCount;
 
@@ -65,6 +67,13 @@ public:
 		const cd::Vec2f& GetUVScale() const  { return uvScale; }
 		void SetUVOffset(const cd::Vec2f& offset) { uvOffset = offset; }
 		void SetUVScale(const cd::Vec2f& scale) { uvScale = scale; }
+	};
+
+	struct PropertyGroup
+	{
+		TextureInfo textureInfo;
+		bool useTexture;
+		std::variant<cd::Vec3f, float> factor;
 	};
 
 public:
@@ -95,7 +104,7 @@ public:
 
 	// Uber shader data.
 	void ActivateShaderFeature(ShaderFeature feature);
-	void DeactiveShaderFeature(ShaderFeature feature);
+	void DeactivateShaderFeature(ShaderFeature feature);
 	void SetShaderFeatures(std::set<ShaderFeature> options) { m_shaderFeatures = cd::MoveTemp(m_shaderFeatures); }
 	std::set<ShaderFeature>& GetShaderFeatures() { return m_shaderFeatures; }
 	const std::set<ShaderFeature>& GetShaderFeatures() const { return m_shaderFeatures; }
@@ -105,25 +114,48 @@ public:
 	void AddTextureBlob(cd::MaterialTextureType textureType, cd::TextureFormat textureFormat, cd::TextureMapMode uMapMode, cd::TextureMapMode vMapMode, TextureBlob textureBlob, uint32_t width, uint32_t height, uint32_t depth = 1);
 	void AddTextureFileBlob(cd::MaterialTextureType textureType, const cd::Material* pMaterial, const cd::Texture& texture, TextureBlob textureBlob);
 
-	const std::map<cd::MaterialTextureType, TextureInfo>& GetTextureResources() const { return m_textureResources; }
-	TextureInfo* GetTextureInfo(cd::MaterialTextureType textureType);
-	const TextureInfo* GetTextureInfo(cd::MaterialTextureType textureType) const;
+	const std::map<cd::MaterialPropertyGroup, PropertyGroup>& GetPropertyGroups() const { return m_propertyGroups; }
+	PropertyGroup* GetPropertyGroup(cd::MaterialPropertyGroup propertyGroup);
+	const PropertyGroup* GetPropertyGroup(cd::MaterialPropertyGroup propertyGroup) const;
 
-	void SetAlbedoColor(cd::Vec3f color) { m_albedoColor = cd::MoveTemp(color); }
-	cd::Vec3f& GetAlbedoColor() { return m_albedoColor; }
-	const cd::Vec3f& GetAlbedoColor() const { return m_albedoColor; }
+	template<class T>
+	void SetFactor(cd::MaterialPropertyGroup propertyGroup, T factor)
+	{
+		auto it = m_propertyGroups.find(propertyGroup);
+		if (m_propertyGroups.end() == it)
+		{
+			return;
+		}
 
-	void SetMetallicFactor(float factor) { m_metallicFactor = factor; }
-	float& GetMetallicFactor() { return m_metallicFactor; }
-	float GetMetallicFactor() const { return m_metallicFactor; }
+		if (auto pValue = std::get_if<T>(&(it->second.factor)))
+		{
+			*pValue = cd::MoveTemp(factor);
+		}
+	}
 
-	void SetRoughnessFactor(float factor) { m_roughnessFactor = factor; }
-	float& GetRoughnessFactor() { return m_roughnessFactor; }
-	float GetRoughnessFactor() const { return m_roughnessFactor; }
+	template<class T>
+	T* GetFactor(cd::MaterialPropertyGroup propertyGroup)
+	{
+		auto it = m_propertyGroups.find(propertyGroup);
+		if (m_propertyGroups.end() == it)
+		{
+			return nullptr;
+		}
 
-	void SetEmissiveColor(cd::Vec3f color) { m_emissiveColor = cd::MoveTemp(color); }
-	cd::Vec3f& GetEmissiveColor() { return m_emissiveColor; }
-	const cd::Vec3f& GetEmissiveColor() const { return m_emissiveColor; }
+		return std::get_if<T>(&(it->second.factor));
+	}
+
+	template<class T>
+	const T* GetFactor(cd::MaterialPropertyGroup propertyGroup) const
+	{
+		auto it = m_propertyGroups.find(propertyGroup);
+		if (m_propertyGroups.end() == it)
+		{
+			return nullptr;
+		}
+
+		return std::get_if<T>(&(it->second.factor));
+	}
 
 	// Cull parameters. 
 	void SetTwoSided(bool value) { m_twoSided = value; }
@@ -145,10 +177,6 @@ private:
 	const engine::MaterialType* m_pMaterialType = nullptr;
 
 	std::string m_name;
-	cd::Vec3f m_albedoColor;
-	float m_metallicFactor;
-	float m_roughnessFactor;
-	cd::Vec3f m_emissiveColor;
 	bool m_twoSided;
 	cd::BlendMode m_blendMode;
 	float m_alphaCutOff;
@@ -160,7 +188,7 @@ private:
 	std::vector<TextureBlob> m_cacheTextureBlobs;
 
 	// Output
-	std::map<cd::MaterialTextureType, TextureInfo> m_textureResources;
+	std::map<cd::MaterialTextureType, PropertyGroup> m_propertyGroups;
 };
 
 }

--- a/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
+++ b/Engine/Source/Runtime/ECWorld/SceneWorld.cpp
@@ -239,16 +239,18 @@ void SceneWorld::AddMaterialToSceneDatabase(engine::Entity entity)
 		return;
 	}
 
-	pMaterialData->SetFloatProperty(cd::MaterialPropertyGroup::Metallic, cd::MaterialProperty::Factor, pMaterialComponent->GetMetallicFactor());
-	pMaterialData->SetFloatProperty(cd::MaterialPropertyGroup::Roughness, cd::MaterialProperty::Factor, pMaterialComponent->GetRoughnessFactor());
+	pMaterialData->SetVec3fProperty(cd::MaterialPropertyGroup::BaseColor, cd::MaterialProperty::Color, *(pMaterialComponent->GetFactor<cd::Vec3f>(cd::MaterialPropertyGroup::BaseColor)));
+	pMaterialData->SetFloatProperty(cd::MaterialPropertyGroup::Metallic, cd::MaterialProperty::Factor, *(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Metallic)));
+	pMaterialData->SetFloatProperty(cd::MaterialPropertyGroup::Roughness, cd::MaterialProperty::Factor, *(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Roughness)));
 	pMaterialData->SetBoolProperty(cd::MaterialPropertyGroup::General, cd::MaterialProperty::TwoSided, pMaterialComponent->GetTwoSided());
 
-	for (int textureTypeValue = 0; textureTypeValue < nameof::enum_count<cd::MaterialTextureType>(); ++textureTypeValue)
+	for (size_t textureTypeValue = 0; textureTypeValue < nameof::enum_count<cd::MaterialTextureType>(); ++textureTypeValue)
 	{
-		if (MaterialComponent::TextureInfo* textureInfo = pMaterialComponent->GetTextureInfo(static_cast<cd::MaterialPropertyGroup>(textureTypeValue)))
+		if (auto pPropertyGroup = pMaterialComponent->GetPropertyGroup(static_cast<cd::MaterialPropertyGroup>(textureTypeValue)); pPropertyGroup)
 		{
-			pMaterialData->SetVec2fProperty(static_cast<cd::MaterialPropertyGroup>(textureTypeValue), cd::MaterialProperty::UVOffset, textureInfo->GetUVOffset());
-			pMaterialData->SetVec2fProperty(static_cast<cd::MaterialPropertyGroup>(textureTypeValue), cd::MaterialProperty::UVScale, textureInfo->GetUVScale());
+			const MaterialComponent::TextureInfo& textureInfo = pPropertyGroup->textureInfo;
+			pMaterialData->SetVec2fProperty(static_cast<cd::MaterialPropertyGroup>(textureTypeValue), cd::MaterialProperty::UVOffset, textureInfo.GetUVOffset());
+			pMaterialData->SetVec2fProperty(static_cast<cd::MaterialPropertyGroup>(textureTypeValue), cd::MaterialProperty::UVScale, textureInfo.GetUVScale());
 		}
 	}
 }

--- a/Engine/Source/Runtime/Material/MaterialType.h
+++ b/Engine/Source/Runtime/Material/MaterialType.h
@@ -13,6 +13,16 @@
 namespace engine
 {
 
+inline const std::map<cd::MaterialTextureType, engine::ShaderFeature> MaterialTextureTypeToShaderFeature
+{
+	{ cd::MaterialTextureType::BaseColor, engine::ShaderFeature::ALBEDO_MAP },
+	{ cd::MaterialTextureType::Normal, engine::ShaderFeature::NORMAL_MAP },
+	{ cd::MaterialTextureType::Occlusion, engine::ShaderFeature::ORM_MAP },
+	{ cd::MaterialTextureType::Roughness, engine::ShaderFeature::ORM_MAP },
+	{ cd::MaterialTextureType::Metallic, engine::ShaderFeature::ORM_MAP },
+	{ cd::MaterialTextureType::Emissive, engine::ShaderFeature::EMISSIVE_MAP },
+};
+
 // Most used in the editor level to define different material types so that raw material asset data can
 // map to a specified MaterialType.
 class MaterialType

--- a/Engine/Source/Runtime/Rendering/BlendShapeRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/BlendShapeRenderer.cpp
@@ -200,20 +200,24 @@ void BlendShapeRenderer::Render(float deltaTime)
 		bgfx::setIndexBuffer(bgfx::IndexBufferHandle{pMeshComponent->GetIndexBuffer()});
 		
 		// Material
-		for (const auto& [textureType, _] : pMaterialComponent->GetTextureResources())
+		for (const auto& [textureType, propertyGroup] : pMaterialComponent->GetPropertyGroups())
 		{
-			if (const MaterialComponent::TextureInfo* pTextureInfo = pMaterialComponent->GetTextureInfo(textureType))
-			{
-				if (cd::MaterialTextureType::BaseColor == textureType)
-				{
-					constexpr StringCrc albedoUVOffsetAndScaleCrc(albedoUVOffsetAndScale);
-					cd::Vec4f uvOffsetAndScaleData(pTextureInfo->GetUVOffset().x(), pTextureInfo->GetUVOffset().y(),
-						pTextureInfo->GetUVScale().x(), pTextureInfo->GetUVScale().y());
-					GetRenderContext()->FillUniform(albedoUVOffsetAndScaleCrc, &uvOffsetAndScaleData, 1);
-				}
+			const MaterialComponent::TextureInfo& textureInfo = propertyGroup.textureInfo;
 
-				bgfx::setTexture(pTextureInfo->slot, bgfx::UniformHandle{ pTextureInfo->samplerHandle }, bgfx::TextureHandle{pTextureInfo->textureHandle});
+			if (!propertyGroup.useTexture || !bgfx::isValid(bgfx::TextureHandle{ textureInfo.textureHandle }))
+			{
+				continue;
 			}
+
+			if (cd::MaterialTextureType::BaseColor == textureType)
+			{
+				constexpr StringCrc albedoUVOffsetAndScaleCrc(albedoUVOffsetAndScale);
+				cd::Vec4f uvOffsetAndScaleData(textureInfo.GetUVOffset().x(), textureInfo.GetUVOffset().y(),
+					textureInfo.GetUVScale().x(), textureInfo.GetUVScale().y());
+				GetRenderContext()->FillUniform(albedoUVOffsetAndScaleCrc, &uvOffsetAndScaleData, 1);
+			}
+
+			bgfx::setTexture(textureInfo.slot, bgfx::UniformHandle{ textureInfo.samplerHandle }, bgfx::TextureHandle{ textureInfo.textureHandle });
 		}
 
 		// Sky
@@ -259,14 +263,17 @@ void BlendShapeRenderer::Render(float deltaTime)
 
 		// Submit uniform values : material settings
 		constexpr StringCrc albedoColorCrc(albedoColor);
-		GetRenderContext()->FillUniform(albedoColorCrc, pMaterialComponent->GetAlbedoColor().begin(), 1);
+		GetRenderContext()->FillUniform(albedoColorCrc, pMaterialComponent->GetFactor<cd::Vec3f>(cd::MaterialPropertyGroup::BaseColor), 1);
 
+		cd::Vec4f metallicRoughnessFactorData(
+			*(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Metallic)),
+			*(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Roughness)),
+			1.0f, 1.0f);
 		constexpr StringCrc mrFactorCrc(metallicRoughnessFactor);
-		cd::Vec4f metallicRoughnessFactorData(pMaterialComponent->GetMetallicFactor(), pMaterialComponent->GetRoughnessFactor(), 1.0f, 1.0f);
 		GetRenderContext()->FillUniform(mrFactorCrc, metallicRoughnessFactorData.begin(), 1);
 
 		constexpr StringCrc emissiveColorCrc(emissiveColor);
-		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetEmissiveColor().begin(), 1);
+		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Emissive), 1);
 
 		// Submit uniform values : light settings
 		auto lightEntities = m_pCurrentSceneWorld->GetLightEntities();

--- a/Engine/Source/Runtime/Rendering/ShaderFeature.h
+++ b/Engine/Source/Runtime/Rendering/ShaderFeature.h
@@ -3,6 +3,7 @@
 #include "Base/Platform.h"
 
 #include <cstdint>
+#include <map>
 #include <set>
 #include <vector>
 

--- a/Engine/Source/Runtime/Rendering/TerrainRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/TerrainRenderer.cpp
@@ -180,14 +180,17 @@ void TerrainRenderer::Render(float deltaTime)
 
 		// Submit  uniform values : material settings
 		constexpr StringCrc albedoColorCrc(albedoColor);
-		GetRenderContext()->FillUniform(albedoColorCrc, pMaterialComponent->GetAlbedoColor().begin(), 1);
+		GetRenderContext()->FillUniform(albedoColorCrc, pMaterialComponent->GetFactor<cd::Vec3f>(cd::MaterialPropertyGroup::BaseColor), 1);
 
+		cd::Vec4f metallicRoughnessFactorData(
+			*(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Metallic)),
+			*(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Roughness)),
+			1.0f, 1.0f);
 		constexpr StringCrc mrFactorCrc(metallicRoughnessFactor);
-		cd::Vec4f metallicRoughnessFactorData(pMaterialComponent->GetMetallicFactor(), pMaterialComponent->GetRoughnessFactor(), 1.0f, 1.0f);
 		GetRenderContext()->FillUniform(mrFactorCrc, metallicRoughnessFactorData.begin(), 1);
 
 		constexpr StringCrc emissiveColorCrc(emissiveColor);
-		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetEmissiveColor().begin(), 1);
+		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Emissive), 1);
 
 		// Submit  uniform values : light settings
 		auto lightEntities = m_pCurrentSceneWorld->GetLightEntities();

--- a/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
@@ -28,7 +28,7 @@ constexpr const char* lutTexture                  = "Textures/lut/ibl_brdf_lut.d
 											      
 constexpr const char* cameraPos                   = "u_cameraPos";
 constexpr const char* albedoColor                 = "u_albedoColor";
-constexpr const char* emissiveColorAndFactor = "u_emissiveColorAndFactor";
+constexpr const char* emissiveColorAndFactor      = "u_emissiveColorAndFactor";
 constexpr const char* metallicRoughnessFactor     = "u_metallicRoughnessFactor";
 											      
 constexpr const char* albedoUVOffsetAndScale      = "u_albedoUVOffsetAndScale";

--- a/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
@@ -129,20 +129,24 @@ void WorldRenderer::Render(float deltaTime)
 		UpdateStaticMeshComponent(pMeshComponent);
 
 		// Material
-		for (const auto& [textureType, _] : pMaterialComponent->GetTextureResources())
+		for (const auto& [textureType, propertyGroup] : pMaterialComponent->GetPropertyGroups())
 		{
-			if (const MaterialComponent::TextureInfo* pTextureInfo = pMaterialComponent->GetTextureInfo(textureType))
-			{
-				if (cd::MaterialTextureType::BaseColor == textureType)
-				{
-					constexpr StringCrc albedoUVOffsetAndScaleCrc(albedoUVOffsetAndScale);
-					cd::Vec4f uvOffsetAndScaleData(pTextureInfo->GetUVOffset().x(), pTextureInfo->GetUVOffset().y(),
-						pTextureInfo->GetUVScale().x(), pTextureInfo->GetUVScale().y());
-					GetRenderContext()->FillUniform(albedoUVOffsetAndScaleCrc, &uvOffsetAndScaleData, 1);
-				}
+			const MaterialComponent::TextureInfo& textureInfo = propertyGroup.textureInfo;
 
-				bgfx::setTexture(pTextureInfo->slot, bgfx::UniformHandle{ pTextureInfo->samplerHandle }, bgfx::TextureHandle{ pTextureInfo->textureHandle });
+			if (!propertyGroup.useTexture || !bgfx::isValid(bgfx::TextureHandle{ textureInfo.textureHandle }))
+			{
+				continue;
 			}
+
+			if (cd::MaterialTextureType::BaseColor == textureType)
+			{
+				constexpr StringCrc albedoUVOffsetAndScaleCrc(albedoUVOffsetAndScale);
+				cd::Vec4f uvOffsetAndScaleData(textureInfo.GetUVOffset().x(), textureInfo.GetUVOffset().y(),
+					textureInfo.GetUVScale().x(), textureInfo.GetUVScale().y());
+				GetRenderContext()->FillUniform(albedoUVOffsetAndScaleCrc, &uvOffsetAndScaleData, 1);
+			}
+
+			bgfx::setTexture(textureInfo.slot, bgfx::UniformHandle{ textureInfo.samplerHandle }, bgfx::TextureHandle{ textureInfo.textureHandle });
 		}
 
 		// Sky
@@ -188,14 +192,17 @@ void WorldRenderer::Render(float deltaTime)
 
 		// Submit uniform values : material settings
 		constexpr StringCrc albedoColorCrc(albedoColor);
-		GetRenderContext()->FillUniform(albedoColorCrc, pMaterialComponent->GetAlbedoColor().begin(), 1);
+		GetRenderContext()->FillUniform(albedoColorCrc, pMaterialComponent->GetFactor<cd::Vec3f>(cd::MaterialPropertyGroup::BaseColor), 1);
 
+		cd::Vec4f metallicRoughnessFactorData(
+			*(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Metallic)),
+			*(pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Roughness)),
+			1.0f, 1.0f);
 		constexpr StringCrc mrFactorCrc(metallicRoughnessFactor);
-		cd::Vec4f metallicRoughnessFactorData(pMaterialComponent->GetMetallicFactor(), pMaterialComponent->GetRoughnessFactor(), 1.0f, 1.0f);
 		GetRenderContext()->FillUniform(mrFactorCrc, metallicRoughnessFactorData.begin(), 1);
 
 		constexpr StringCrc emissiveColorCrc(emissiveColor);
-		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetEmissiveColor().begin(), 1);
+		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Emissive), 1);
 
 		// Submit uniform values : light settings
 		auto lightEntities = m_pCurrentSceneWorld->GetLightEntities();

--- a/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
+++ b/Engine/Source/Runtime/Rendering/WorldRenderer.cpp
@@ -28,7 +28,7 @@ constexpr const char* lutTexture                  = "Textures/lut/ibl_brdf_lut.d
 											      
 constexpr const char* cameraPos                   = "u_cameraPos";
 constexpr const char* albedoColor                 = "u_albedoColor";
-constexpr const char* emissiveColor               = "u_emissiveColor";
+constexpr const char* emissiveColorAndFactor = "u_emissiveColorAndFactor";
 constexpr const char* metallicRoughnessFactor     = "u_metallicRoughnessFactor";
 											      
 constexpr const char* albedoUVOffsetAndScale      = "u_albedoUVOffsetAndScale";
@@ -64,7 +64,7 @@ void WorldRenderer::Warmup()
 
 	GetRenderContext()->CreateUniform(cameraPos, bgfx::UniformType::Vec4, 1);
 	GetRenderContext()->CreateUniform(albedoColor, bgfx::UniformType::Vec4, 1);
-	GetRenderContext()->CreateUniform(emissiveColor, bgfx::UniformType::Vec4, 1);
+	GetRenderContext()->CreateUniform(emissiveColorAndFactor, bgfx::UniformType::Vec4, 1);
 	GetRenderContext()->CreateUniform(metallicRoughnessFactor, bgfx::UniformType::Vec4, 1);
 	GetRenderContext()->CreateUniform(albedoUVOffsetAndScale, bgfx::UniformType::Vec4, 1);
 	GetRenderContext()->CreateUniform(alphaCutOff, bgfx::UniformType::Vec4, 1);
@@ -201,8 +201,8 @@ void WorldRenderer::Render(float deltaTime)
 		constexpr StringCrc mrFactorCrc(metallicRoughnessFactor);
 		GetRenderContext()->FillUniform(mrFactorCrc, metallicRoughnessFactorData.begin(), 1);
 
-		constexpr StringCrc emissiveColorCrc(emissiveColor);
-		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetFactor<float>(cd::MaterialPropertyGroup::Emissive), 1);
+		constexpr StringCrc emissiveColorCrc(emissiveColorAndFactor);
+		GetRenderContext()->FillUniform(emissiveColorCrc, pMaterialComponent->GetFactor<cd::Vec4f>(cd::MaterialPropertyGroup::Emissive), 1);
 
 		// Submit uniform values : light settings
 		auto lightEntities = m_pCurrentSceneWorld->GetLightEntities();


### PR DESCRIPTION
![Snipaste_2023-12-22_16-01-00](https://github.com/CatDogEngine/CatDogEngine/assets/69386319/1e68e0f8-a61b-4ab3-80ff-ff6e15e3d7a6)
![Snipaste_2023-12-22_16-01-04](https://github.com/CatDogEngine/CatDogEngine/assets/69386319/f64592f8-9034-46d9-89cb-ce1ba121b314)

Properties that do not use textures display "No Resources".
Also removes the warning about no textures in ECWorldConsumer::AddMaterial.
